### PR TITLE
Feature/0002 approval

### DIFF
--- a/CMMS/CMMS.csproj
+++ b/CMMS/CMMS.csproj
@@ -110,13 +110,19 @@
   </ItemGroup>
   <ItemGroup>
     <Folder Include="CustomizationPlugin\" />
+    <Folder Include="DAC\DBBacked\" />
     <Folder Include="DAC\DerivedClasses\" />
     <Folder Include="DAC\Filters\" />
     <Folder Include="DAC\NonDBBacked\" />
     <Folder Include="DAC\PXProjections\" />
     <Folder Include="Extension\DAC\" />
+    <Folder Include="Extension\Graph\" />
+    <Folder Include="Graph\Entry\" />
     <Folder Include="Graph\Inquiry\" />
+    <Folder Include="Graph\Maintenance\" />
     <Folder Include="Graph\Processing\" />
+    <Folder Include="Graph\Setup\" />
+    <Folder Include="Utility\" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/CMMS/CMMS.csproj
+++ b/CMMS/CMMS.csproj
@@ -48,6 +48,7 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\CMMS_22_111_0020\Bin\PX.Data.BQL.Fluent.dll</HintPath>
     </Reference>
+    <Reference Include="PX.DbServices, Version=1.0.0.0, Culture=neutral, PublicKeyToken=3b136cac2f602b8e" />
     <Reference Include="PX.Objects, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\CMMS_22_111_0020\Bin\PX.Objects.dll</HintPath>
@@ -94,6 +95,7 @@
     <Compile Include="DAC\DBBacked\WOSchedule.cs" />
     <Compile Include="DAC\DBBacked\WOSetup.cs" />
     <Compile Include="DAC\DBBacked\WOSetupApproval.cs" />
+    <Compile Include="Extension\Graph\EPApprovalMapMaint.cs" />
     <Compile Include="Graph\Entry\WOOrderEntry.cs" />
     <Compile Include="Graph\Entry\Workflow\WOOrderEntry_ApprovalWorkflow.cs" />
     <Compile Include="Graph\Entry\Workflow\WOOrderEntry_Workflow.cs" />
@@ -108,19 +110,13 @@
   </ItemGroup>
   <ItemGroup>
     <Folder Include="CustomizationPlugin\" />
-    <Folder Include="DAC\DBBacked\" />
     <Folder Include="DAC\DerivedClasses\" />
     <Folder Include="DAC\Filters\" />
     <Folder Include="DAC\NonDBBacked\" />
     <Folder Include="DAC\PXProjections\" />
     <Folder Include="Extension\DAC\" />
-    <Folder Include="Extension\Graph\" />
-    <Folder Include="Graph\Entry\" />
     <Folder Include="Graph\Inquiry\" />
-    <Folder Include="Graph\Maintenance\" />
     <Folder Include="Graph\Processing\" />
-    <Folder Include="Graph\Setup\" />
-    <Folder Include="Utility\" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/CMMS/DAC/DBBacked/WOClass.cs
+++ b/CMMS/DAC/DBBacked/WOClass.cs
@@ -1,6 +1,5 @@
 ﻿using PX.Data;
 using PX.Data.ReferentialIntegrity.Attributes;
-using PX.Objects.GL;
 using System;
 
 namespace CMMSlite.WO
@@ -23,6 +22,7 @@ namespace CMMSlite.WO
         #region WOClassID
         [PXDBString(15, IsKey = true, IsUnicode = true, InputMask = ">aaaaaaaaaaaaaaa")]
         [PXDefault]
+        [PXReferentialIntegrityCheck]
         [PXSelector(
             typeof(WOClass.wOClassID),
             typeof(WOClass.wOClassID),

--- a/CMMS/DAC/DBBacked/WOClass.cs
+++ b/CMMS/DAC/DBBacked/WOClass.cs
@@ -1,4 +1,5 @@
 ﻿using PX.Data;
+using PX.Data.EP;
 using PX.Data.ReferentialIntegrity.Attributes;
 using System;
 
@@ -16,20 +17,21 @@ namespace CMMSlite.WO
         }
         public static class FK
         {
+            public class WorkOrder : WOOrder.PK.ForeignKeyOf<WOClass>.By<wOClassID> { }
         }
         #endregion
 
         #region WOClassID
         [PXDBString(15, IsKey = true, IsUnicode = true, InputMask = ">aaaaaaaaaaaaaaa")]
-        [PXDefault]
-        [PXReferentialIntegrityCheck]
+        [PXDefault(PersistingCheck = PXPersistingCheck.NullOrBlank)]
+        [PXUIField(DisplayName = Messages.FieldWOClassID, Visibility = PXUIVisibility.SelectorVisible)]
         [PXSelector(
             typeof(WOClass.wOClassID),
             typeof(WOClass.wOClassID),
             typeof(WOClass.descr),
             Filterable = true
             )]
-        [PXUIField(DisplayName = Messages.FieldWOClassID)]
+        [PXFieldDescription]
         public virtual string WOClassID { get; set; }
         public abstract class wOClassID : PX.Data.BQL.BqlString.Field<wOClassID> { }
         #endregion

--- a/CMMS/DAC/DBBacked/WOOrder.cs
+++ b/CMMS/DAC/DBBacked/WOOrder.cs
@@ -2,6 +2,7 @@
 using PX.Data.EP;
 using PX.Data.ReferentialIntegrity.Attributes;
 using PX.Objects.AM;
+using PX.Objects.CR;
 using PX.Objects.CS;
 using PX.TM;
 using System;
@@ -58,7 +59,7 @@ namespace CMMSlite.WO
         #region WOClassID
         [PXDBString(15, IsUnicode = true, InputMask = ">aaaaaaaaaaaaaaa")]
         [PXDefault]
-        [PXReferentialIntegrityCheck]
+        [PXForeignReference(typeof(Field<wOClassID>.IsRelatedTo<WOClass.wOClassID>))]
         [PXSelector(
             typeof(WOClass.wOClassID),
             typeof(WOClass.wOClassID),
@@ -246,6 +247,36 @@ namespace CMMSlite.WO
         [PXNote]
         public virtual Guid? NoteID { get; set; }
         public abstract class noteID : PX.Data.BQL.BqlGuid.Field<noteID> { }
+        #endregion
+
+        #region IAssign Members
+        int? PX.Data.EP.IAssign.WorkgroupID
+        {
+            get
+            {
+                return WorkgroupID;
+            }
+            set
+            {
+                WorkgroupID = value;
+            }
+        }
+
+        int? PX.Data.EP.IAssign.OwnerID
+        {
+            get { return OwnerID; }
+            set { OwnerID = value; }
+        }
+        #endregion
+
+        #region Attributes
+        public abstract class attributes : BqlAttributes.Field<attributes> { }
+        [CRAttributesField(typeof(wOClassID))]
+        public virtual string[] Attributes { get; set; }
+        public virtual string ClassID
+        {
+            get { return WOClassID; }
+        }
         #endregion
 
         #region Statuses

--- a/CMMS/DAC/DBBacked/WOOrder.cs
+++ b/CMMS/DAC/DBBacked/WOOrder.cs
@@ -78,7 +78,7 @@ namespace CMMSlite.WO
             typeof(WOClass.descr),
             Filterable = true
             )]
-        [PXUIField(DisplayName = Messages.FieldWOClassID)]
+        [PXUIField(DisplayName = Messages.FieldWOClass)]
         public virtual string WOClassID { get; set; }
         public abstract class wOClassID : PX.Data.BQL.BqlString.Field<wOClassID> { }
         #endregion

--- a/CMMS/DAC/DBBacked/WOOrder.cs
+++ b/CMMS/DAC/DBBacked/WOOrder.cs
@@ -206,9 +206,9 @@ namespace CMMSlite.WO
         #endregion
 
         #region RequestApproval
-        [PXDBBool()]
+        [PXDBBool]
         [PXUIField(Visible = false)]
-        [PXDBDefault(typeof(WOSetup.wORequestApproval))]
+        [PXDefault(typeof(WOSetup.wORequestApproval))]
         public virtual bool? RequestApproval { get; set; }
         public abstract class requestApproval : PX.Data.BQL.BqlBool.Field<requestApproval> { }
         #endregion

--- a/CMMS/DAC/DBBacked/WOOrder.cs
+++ b/CMMS/DAC/DBBacked/WOOrder.cs
@@ -26,6 +26,18 @@ namespace CMMSlite.WO
     [PXCacheName(Messages.DACWOOrder)]
     public class WOOrder : IBqlTable, IAssign
     {
+
+        #region Keys
+        public class PK : PrimaryKeyOf<WOOrder>.By<workOrderID>
+        {
+            public static WOOrder Find(PXGraph graph, string workOrderID) => FindBy(graph, workOrderID);
+        }
+        public static class FK
+        {
+            public class WorkOrderClass : WOClass.PK.ForeignKeyOf<WOClass>.By<wOClassID> { }
+        }
+        #endregion
+
         #region WorkOrderType
         [PXDBString(1, IsKey = true, IsFixed = true, InputMask = "")]
         [WorkOrderTypes.List]

--- a/CMMS/Extension/Graph/EPApprovalMapMaint.cs
+++ b/CMMS/Extension/Graph/EPApprovalMapMaint.cs
@@ -44,6 +44,7 @@ namespace CMMSlite.WO
                 typeof(WOOrderEntry).FullName,
             }.Contains(Base.AssigmentMap.Current?.GraphType, new PX.Data.CompareIgnoreCase());
 
+            // Make UI fields visible for supported custom screens
             if (isSupportedCustomType)
             {
                 PXUIFieldAttribute.SetVisible<EP.EPRule.reasonForApprove>(Base.Nodes.Cache, Base.Nodes.Current, isSupportedCustomType && row.StepID != null);

--- a/CMMS/Extension/Graph/EPApprovalMapMaint.cs
+++ b/CMMS/Extension/Graph/EPApprovalMapMaint.cs
@@ -1,0 +1,56 @@
+﻿using PX.Data;
+using System.Collections.Generic;
+using System.Linq;
+using EP = PX.Objects.EP;
+
+namespace CMMSlite.WO
+{
+    public class EPApprovalMapMaint_Extension : PXGraphExtension<EP.EPApprovalMapMaint>
+    {
+        public static bool IsActive() => true;
+
+        #region Override GetEntityTypeScreens - Enable Approval Maps for New Screens
+        public delegate IEnumerable<string> GetEntityTypeScreensDelegate();
+        [PXOverride]
+        public IEnumerable<string> GetEntityTypeScreens(GetEntityTypeScreensDelegate baseMethod)
+        {
+            IEnumerable<string> entities = baseMethod();
+            List<string> list = new List<string>();
+
+            foreach (string s in entities)
+            {
+                list.Add(s);
+            }
+            list.Add("WO301000"); // Work Order Entry
+
+            return list;
+
+        }
+        #endregion
+
+        #region EPRule_RowSelected - Override to Enable Approve/Reject Reasons for New Graphs 
+        protected virtual void EPRule_RowSelected(PXCache sender, PXRowSelectedEventArgs e, PXRowSelected baseEvent)
+        {
+            // baseEvent will disable visibility of reason fields unless setup in Standard Acumatica
+            baseEvent.Invoke(sender, e);
+
+            EP.EPRule row = e.Row as EP.EPRule;
+            if (row == null)
+                return;
+
+            // Add custom screens that should toggle the reason fields to visible
+            bool isSupportedCustomType = new List<string>()
+            {
+                typeof(WOOrderEntry).FullName,
+            }.Contains(Base.AssigmentMap.Current?.GraphType, new PX.Data.CompareIgnoreCase());
+
+            if (isSupportedCustomType)
+            {
+                PXUIFieldAttribute.SetVisible<EP.EPRule.reasonForApprove>(Base.Nodes.Cache, Base.Nodes.Current, isSupportedCustomType && row.StepID != null);
+                PXUIFieldAttribute.SetVisible<EP.EPRule.reasonForReject>(Base.Nodes.Cache, Base.Nodes.Current, isSupportedCustomType && row.StepID != null);
+            }
+        }
+        #endregion
+
+    }
+}

--- a/CMMS/Graph/Entry/WOOrderEntry.cs
+++ b/CMMS/Graph/Entry/WOOrderEntry.cs
@@ -22,14 +22,14 @@ namespace CMMSlite.WO
             .View CurrentDocument;
 
         [PXViewName(Messages.ViewTransactions)]
-        [PXImport(typeof(WOLine))]
+        [PXImport]
         public SelectFrom<WOLine>
             .LeftJoin<WOEquipment>.On<WOEquipment.equipmentID.IsEqual<WOLine.equipmentID>>
             .Where<WOLine.workOrderID.IsEqual<WOOrder.workOrderID.FromCurrent>>
             .View Transactions;
 
         [PXViewName(Messages.ViewWOLineItems)]
-        [PXImport(typeof(WOLineItem))]
+        [PXImport]
         public SelectFrom<WOLineItem>
             .InnerJoin<InventoryItem>.On<InventoryItem.inventoryID.IsEqual<WOLineItem.inventoryID>>
             .Where<WOLineItem.workOrderID.IsEqual<WOLine.workOrderID.FromCurrent>
@@ -37,14 +37,14 @@ namespace CMMSlite.WO
             .View LineItems;
 
         [PXViewName(Messages.ViewWOLineLabor)]
-        [PXImport(typeof(WOLineLabor))]
+        [PXImport]
         public SelectFrom<WOLineLabor>
             .Where<WOLineLabor.workOrderID.IsEqual<WOLine.workOrderID.FromCurrent>
                 .And<WOLineLabor.wOLineNbr.IsEqual<WOLine.lineNbr.FromCurrent>>>
             .View LineLabor;
 
         [PXViewName(Messages.ViewWOLineTools)]
-        [PXImport(typeof(WOLineTool))]
+        [PXImport]
         public SelectFrom<WOLineTool>
             .InnerJoin<InventoryItem>.On<InventoryItem.inventoryID.IsEqual<WOLineTool.inventoryID>>
             .Where<WOLineTool.workOrderID.IsEqual<WOLine.workOrderID.FromCurrent>
@@ -52,12 +52,14 @@ namespace CMMSlite.WO
             .View LineTools;
 
         [PXViewName(Messages.ViewWOLineMeasurements)]
+        [PXImport]
         public SelectFrom<WOLineMeasure>
             .Where<WOLineMeasure.workOrderID.IsEqual<WOLine.workOrderID.FromCurrent>
                 .And<WOLineMeasure.wOLineNbr.IsEqual<WOLine.lineNbr.FromCurrent>>>
             .View LineMeasurements;
 
         [PXViewName(Messages.ViewWOLineFailureModes)]
+        [PXImport]
         public SelectFrom<WOLineFailure>
             .Where<WOLineFailure.workOrderID.IsEqual<WOLine.workOrderID.FromCurrent>
                 .And<WOLineFailure.wOLineNbr.IsEqual<WOLine.lineNbr.FromCurrent>>>

--- a/CMMS/Graph/Entry/WOOrderEntry.cs
+++ b/CMMS/Graph/Entry/WOOrderEntry.cs
@@ -176,6 +176,15 @@ namespace CMMSlite.WO
             e.NewValue = Setup.Current.WORequestApproval;
         }
         #endregion
+
+        #region WOOrder_RowPersisting
+        protected void _(Events.RowPersisting<WOOrder> e)
+        {
+            WOOrder row = e.Row;
+            if(row != null) row.RequestApproval = Setup.Current.WORequestApproval;
+        }
+        #endregion
+
         #endregion
 
     }

--- a/CMMS/Graph/Entry/WOOrderEntry.cs
+++ b/CMMS/Graph/Entry/WOOrderEntry.cs
@@ -1,6 +1,7 @@
 ﻿using PX.Data;
 using PX.Data.BQL.Fluent;
 using PX.Data.WorkflowAPI;
+using PX.Objects.AM;
 using PX.Objects.CR;
 using PX.Objects.EP;
 using PX.Objects.IN;
@@ -21,12 +22,14 @@ namespace CMMSlite.WO
             .View CurrentDocument;
 
         [PXViewName(Messages.ViewTransactions)]
+        [PXImport(typeof(WOLine))]
         public SelectFrom<WOLine>
             .LeftJoin<WOEquipment>.On<WOEquipment.equipmentID.IsEqual<WOLine.equipmentID>>
             .Where<WOLine.workOrderID.IsEqual<WOOrder.workOrderID.FromCurrent>>
             .View Transactions;
 
         [PXViewName(Messages.ViewWOLineItems)]
+        [PXImport(typeof(WOLineItem))]
         public SelectFrom<WOLineItem>
             .InnerJoin<InventoryItem>.On<InventoryItem.inventoryID.IsEqual<WOLineItem.inventoryID>>
             .Where<WOLineItem.workOrderID.IsEqual<WOLine.workOrderID.FromCurrent>
@@ -34,12 +37,14 @@ namespace CMMSlite.WO
             .View LineItems;
 
         [PXViewName(Messages.ViewWOLineLabor)]
+        [PXImport(typeof(WOLineLabor))]
         public SelectFrom<WOLineLabor>
             .Where<WOLineLabor.workOrderID.IsEqual<WOLine.workOrderID.FromCurrent>
                 .And<WOLineLabor.wOLineNbr.IsEqual<WOLine.lineNbr.FromCurrent>>>
             .View LineLabor;
 
         [PXViewName(Messages.ViewWOLineTools)]
+        [PXImport(typeof(WOLineTool))]
         public SelectFrom<WOLineTool>
             .InnerJoin<InventoryItem>.On<InventoryItem.inventoryID.IsEqual<WOLineTool.inventoryID>>
             .Where<WOLineTool.workOrderID.IsEqual<WOLine.workOrderID.FromCurrent>

--- a/CMMS/Graph/Entry/WOOrderEntry.cs
+++ b/CMMS/Graph/Entry/WOOrderEntry.cs
@@ -1,14 +1,17 @@
 ﻿using PX.Data;
 using PX.Data.BQL.Fluent;
 using PX.Data.WorkflowAPI;
+using PX.Objects.CR;
 using PX.Objects.EP;
 using PX.Objects.IN;
 using System.Collections;
+using static PX.Objects.AM.ProductionBomCopyBase;
 
 namespace CMMSlite.WO
 {
     public class WOOrderEntry : PXGraph<WOOrderEntry, WOOrder>
     {
+        #region Views
         [PXViewName(Messages.ViewDocument)]
         public SelectFrom<WOOrder>.View Document;
 
@@ -57,6 +60,10 @@ namespace CMMSlite.WO
 
         public PXSetup<WOSetup> Setup;
         public SelectFrom<WOSetupApproval>.View SetupApproval;
+
+        [PXViewName(PX.Objects.CR.Messages.Answers)]
+        public CRAttributeList<WOOrder> Answers;
+        #endregion
 
         #region Hook to Standard Approval System
         [PXViewName(Messages.ViewApproval)]
@@ -114,12 +121,24 @@ namespace CMMSlite.WO
         }
         #endregion
 
+        #region Actions
+        #region initializeState
         public PXAutoAction<WOOrder> initializeState;
+        #endregion
 
-        //public PXAction<WOOrder> putOnHold;
-        //[PXButton(CommitChanges = true), PXUIField(DisplayName = "Hold", MapEnableRights = PXCacheRights.Select)]
-        //protected virtual IEnumerable PutOnHold(PXAdapter adapter) => adapter.Get<WOOrder>();
+        #region Hold Action
+        public PXAction<WOOrder> putOnHold;
+        [PXButton(CommitChanges = true), PXUIField(DisplayName = "Hold", MapEnableRights = PXCacheRights.Select)]
+        protected virtual IEnumerable PutOnHold(PXAdapter adapter) => adapter.Get<WOOrder>();
+        #endregion
 
+        #region RemoveHold Action
+        public PXAction<WOOrder> removeHold;
+        [PXButton(CommitChanges = true), PXUIField(DisplayName = "Remove Hold", MapEnableRights = PXCacheRights.Select)]
+        protected virtual IEnumerable RemoveHold(PXAdapter adapter) => adapter.Get<WOOrder>();
+        #endregion
+
+        #region Schedule Action
         public PXAction<WOOrder> schedule;
         [PXButton(CommitChanges = true), PXUIField(DisplayName = "Schedule")]
         protected virtual IEnumerable Schedule(PXAdapter adapter)
@@ -134,6 +153,30 @@ namespace CMMSlite.WO
 
             return adapter.Get<WOOrder>();
         }
+        #endregion
+
+        #region Open Action
+        public PXAction<WOOrder> open;
+        [PXButton(CommitChanges = true), PXUIField(DisplayName = "Open", MapEnableRights = PXCacheRights.Select)]
+        protected virtual IEnumerable Open(PXAdapter adapter) => adapter.Get<WOOrder>();
+        #endregion
+
+        #region Complete Action
+        public PXAction<WOOrder> complete;
+        [PXButton(CommitChanges = true), PXUIField(DisplayName = "Complete", MapEnableRights = PXCacheRights.Select)]
+        protected virtual IEnumerable Complete(PXAdapter adapter) => adapter.Get<WOOrder>();
+        #endregion
+
+        #endregion
+
+        #region Events
+        #region WOOrder_RequestApproval_FieldDefaulting
+        protected void _(Events.FieldDefaulting<WOOrder.requestApproval> e)
+        {
+            e.NewValue = Setup.Current.WORequestApproval;
+        }
+        #endregion
+        #endregion
 
     }
 }

--- a/CMMS/Graph/Entry/WOOrderEntry.cs
+++ b/CMMS/Graph/Entry/WOOrderEntry.cs
@@ -175,16 +175,6 @@ namespace CMMSlite.WO
         #endregion
 
         #region Events
-
-        #region WOOrder
-
-        protected void _(Events.FieldDefaulting<WOOrder.requestApproval> e)
-        {
-            e.NewValue = Setup.Current.WORequestApproval;
-        }
-
-        #endregion
-
         #endregion
 
     }

--- a/CMMS/Graph/Entry/WOOrderEntry.cs
+++ b/CMMS/Graph/Entry/WOOrderEntry.cs
@@ -175,19 +175,14 @@ namespace CMMSlite.WO
         #endregion
 
         #region Events
-        #region WOOrder_RequestApproval_FieldDefaulting
+
+        #region WOOrder
+
         protected void _(Events.FieldDefaulting<WOOrder.requestApproval> e)
         {
             e.NewValue = Setup.Current.WORequestApproval;
         }
-        #endregion
 
-        #region WOOrder_RowPersisting
-        protected void _(Events.RowPersisting<WOOrder> e)
-        {
-            WOOrder row = e.Row;
-            if(row != null) row.RequestApproval = Setup.Current.WORequestApproval;
-        }
         #endregion
 
         #endregion

--- a/CMMS/Graph/Entry/Workflow/WOOrderEntry_ApprovalWorkflow.cs
+++ b/CMMS/Graph/Entry/Workflow/WOOrderEntry_ApprovalWorkflow.cs
@@ -1,5 +1,6 @@
 ﻿using PX.Data;
 using PX.Data.WorkflowAPI;
+using PX.Objects.CS;
 
 namespace CMMSlite.WO
 {
@@ -25,7 +26,7 @@ namespace CMMSlite.WO
                 using (PXDataRecord setup = PXDatabase.SelectSingle<WOSetup>(new PXDataField<WOSetup.wORequestApproval>()))
                 {
                     if (setup != null)
-                        requestApproval = (bool)setup.GetBoolean(0);
+                        requestApproval = ((bool?)setup.GetBoolean(0) == true);
                 }
             }
 
@@ -154,6 +155,7 @@ namespace CMMSlite.WO
                                         fields.AddAllFields<WOLineTool>(c => c.IsDisabled());
                                         fields.AddAllFields<WOLineMeasure>(c => c.IsDisabled());
                                         fields.AddAllFields<WOLineFailure>(c => c.IsDisabled());
+                                        fields.AddAllFields<CSAnswers>(c => c.IsDisabled());
                                     }));
                             states
                                 .Add<State.rejected>(flowState => flowState
@@ -172,6 +174,7 @@ namespace CMMSlite.WO
                                         fields.AddAllFields<WOLineTool>(c => c.IsDisabled());
                                         fields.AddAllFields<WOLineMeasure>(c => c.IsDisabled());
                                         fields.AddAllFields<WOLineFailure>(c => c.IsDisabled());
+                                        fields.AddAllFields<CSAnswers>(c => c.IsDisabled());
                                     }));
                             states
                                 .Add<State.approved>(flowState => flowState
@@ -191,6 +194,7 @@ namespace CMMSlite.WO
                                         fields.AddAllFields<WOLineTool>(c => c.IsDisabled());
                                         fields.AddAllFields<WOLineMeasure>(c => c.IsDisabled());
                                         fields.AddAllFields<WOLineFailure>(c => c.IsDisabled());
+                                        fields.AddAllFields<CSAnswers>(c => c.IsDisabled());
                                     }));
                         })
                         #region AutoAction - Add the action to the state and then Updated it like this example

--- a/CMMS/Graph/Entry/Workflow/WOOrderEntry_ApprovalWorkflow.cs
+++ b/CMMS/Graph/Entry/Workflow/WOOrderEntry_ApprovalWorkflow.cs
@@ -1,107 +1,292 @@
-﻿//using PX.Data;
-//using PX.Data.WorkflowAPI;
+﻿using PX.Data;
+using PX.Data.WorkflowAPI;
 
-//namespace CMMSlite.WO
-//{
-//    using static PX.Data.WorkflowAPI.BoundedTo<WOOrderEntry, WOOrder>;
-//    using static WOOrder;
-//    using State = WOOrder.Statuses;
-//    using This = WOOrderEntry_ApprovalWorkflow;
+namespace CMMSlite.WO
+{
+    using static BoundedTo<WOOrderEntry, WOOrder>;
+    using static WOOrder;
+    using State = WOOrder.Statuses;
 
-//    public class WOOrderEntry_ApprovalWorkflow : PXGraphExtension<WOOrderEntry_Workflow, WOOrderEntry>
-//    {
-//        public static bool IsActive() => true;
+    public class WOOrderEntry_ApprovalWorkflow : PXGraphExtension<WOOrderEntry_Workflow, WOOrderEntry>
+    {
+        public static bool IsActive() => true;
 
-//        private class WOApprovalSettings : IPrefetchable
-//        {
-//            private static WOApprovalSettings Current => PXDatabase.GetSlot<WOApprovalSettings>(nameof(WOApprovalSettings), typeof(WOSetup), typeof(WOSetupApproval));
+        #region Approval Settings
+        private class AUGApprovalSettings : IPrefetchable
+        {
+            private static AUGApprovalSettings Current =>
+                PXDatabase.GetSlot<AUGApprovalSettings>(nameof(AUGApprovalSettings), typeof(WOSetup), typeof(WOSetupApproval));
 
-//            public static bool IsActive => Current.OrderRequestApproval;
+            public static bool IsActive => Current.requestApproval;
+            private bool requestApproval;
 
-//            private bool OrderRequestApproval;
+            void IPrefetchable.Prefetch()
+            {
+                using (PXDataRecord setup = PXDatabase.SelectSingle<WOSetup>(new PXDataField<WOSetup.wORequestApproval>()))
+                {
+                    if (setup != null)
+                        requestApproval = (bool)setup.GetBoolean(0);
+                }
+            }
 
-//            void IPrefetchable.Prefetch()
-//            {
-//                using (PXDataRecord wOSetup = PXDatabase.SelectSingle<WOSetup>(new PXDataField<WOSetup.wORequestApproval>()))
-//                {
-//                    if (wOSetup != null)
-//                        OrderRequestApproval = (bool)wOSetup.GetBoolean(0);
-//                }
-//            }
+            private static bool RequestApproval()
+            {
+                using (PXDataRecord approval = PXDatabase.SelectSingle<WOSetupApproval>(
+                    new PXDataField<WOSetupApproval.approvalID>()))
+                {
+                    if (approval != null)
+                        return (int?)approval.GetInt32(0) != null;
+                }
+                return false;
+            }
+        }
+        #endregion
 
-//            private static bool RequestApproval(string orderType)
-//            {
-//                using (PXDataRecord WOApproval = PXDatabase.SelectSingle<WOSetupApproval>(
-//                    new PXDataField<WOSetupApproval.approvalID>()))
-//                {
-//                    if (WOApproval != null)
-//                        return (int?)WOApproval.GetInt32(0) != null;
-//                }
-//                return false;
-//            }
-//        }
+        public const string ApproveActionName = "Approve";
+        public const string RejectActionName = "Reject";
 
+        private static bool ApprovalIsActive => PXAccess.FeatureInstalled<PX.Objects.CS.FeaturesSet.approvalWorkflow>() && AUGApprovalSettings.IsActive;
 
-//        public const string ApproveActionName = "Approve";
-//        public const string RejectActionName = "Reject";
+        #region Override Configure - Show or Hide Approval Workflow
+        [PXWorkflowDependsOnType(typeof(WOSetup), typeof(WOSetupApproval))]
+        public override void Configure(PXScreenConfiguration config)
+        {
+            if (ApprovalIsActive)
+                Configure(config.GetScreenConfigurationContext<WOOrderEntry, WOOrder>());
+            else
+                HideApproveAndRejectActions(config.GetScreenConfigurationContext<WOOrderEntry, WOOrder>());
+        }
+        #endregion
 
-//        [PXWorkflowDependsOnType(typeof(WOSetup), typeof(WOSetupApproval))]
-//        public override void Configure(PXScreenConfiguration config)
-//        {
-//            if (Base.Document.Current?.RequestApproval == true)
-//                //if (true)
-//                Configure(config.GetScreenConfigurationContext<WOOrderEntry, WOOrder>());
-//            else
-//                HideApproveAndRejectActions(config.GetScreenConfigurationContext<WOOrderEntry, WOOrder>());
-//        }
+        #region HideApproveAndRejectActions
+        protected virtual void HideApproveAndRejectActions(WorkflowContext<WOOrderEntry, WOOrder> context)
+        {
+            var approve = context.ActionDefinitions
+                .CreateNew(ApproveActionName, a => a
+                .WithCategory(PredefinedCategory.Actions)
+                .PlaceAfter(g => g.putOnHold)
+                .IsHiddenAlways());
+            var reject = context.ActionDefinitions
+                .CreateNew(RejectActionName, a => a
+                .WithCategory(PredefinedCategory.Actions)
+                .PlaceAfter(approve)
+                .IsHiddenAlways());
 
-//        protected virtual void HideApproveAndRejectActions(WorkflowContext<WOOrderEntry, WOOrder> context)
-//        {
-//            var approve = context.ActionDefinitions
-//                .CreateNew(ApproveActionName, a => a
-//                .WithCategory(PredefinedCategory.Actions)
-//                .PlaceAfter(g => g.putOnHold)
-//                .IsHiddenAlways());
-//            var reject = context.ActionDefinitions
-//                .CreateNew(RejectActionName, a => a
-//                .WithCategory(PredefinedCategory.Actions)
-//                .PlaceAfter(approve)
-//                .IsHiddenAlways());
+            context.UpdateScreenConfigurationFor(screen =>
+            {
+                return screen
+                    .WithActions(actions =>
+                    {
+                        actions.Add(approve);
+                        actions.Add(reject);
+                    });
+            });
+        }
+        #endregion
 
-//            context.UpdateScreenConfigurationFor(screen =>
-//            {
-//                return screen
-//                    .WithActions(actions =>
-//                    {
-//                        actions.Add(approve);
-//                        actions.Add(reject);
-//                    });
-//            });
-//        }
+        protected virtual void Configure(WorkflowContext<WOOrderEntry, WOOrder> context)
+        {
+            #region Conditions
+            Condition Bql<T>() where T : IBqlUnary, new() => context.Conditions.FromBql<T>();
+            Condition Existing(string name) => (Condition)context.Conditions.Get(name);
+            var conditions = new
+            {
+                IsPendingApproval
+                    = Bql<status.IsEqual<State.pendingApproval>>(),
+                IsApproved
+                    = Bql<approved.IsEqual<True>>(),
+                IsRejected
+                    = Bql<rejected.IsEqual<True>>(),
 
+                IsOnHold
+                    = Existing("IsOnHold"),
+                ApprovalRequired
+                    = Bql<requestApproval.IsEqual<True>>(),
+            }.AutoNameConditions();
+            #endregion
 
-//        protected virtual void Configure(WorkflowContext<WOOrderEntry, WOOrder> context)
-//        {
-//            var approve = context.ActionDefinitions
-//                .CreateNew(ApproveActionName, a => a
-//                .WithCategory(PredefinedCategory.Actions)
-//                .PlaceAfter(g => g.putOnHold)
-//                );
-//            var reject = context.ActionDefinitions
-//                .CreateNew(RejectActionName, a => a
-//                .WithCategory(PredefinedCategory.Actions)
-//                .PlaceAfter(approve)
-//                );
+            #region Actions
+            var approve = context.ActionDefinitions
+                .CreateNew(ApproveActionName, a => a
+                .WithCategory(PredefinedCategory.Actions)
+                .PlaceAfter(g => g.putOnHold)
+                .IsHiddenWhen(!conditions.IsPendingApproval)
+                .WithFieldAssignments(fas =>
+                {
+                    fas.Add<approved>(true);
+                }));
+            var reject = context.ActionDefinitions
+                .CreateNew(RejectActionName, a => a
+                .WithCategory(PredefinedCategory.Actions)
+                .PlaceAfter(approve)
+                .IsHiddenWhen(!conditions.IsPendingApproval)
+                .WithFieldAssignments(fas =>
+                {
+                    fas.Add<rejected>(true);
+                }));
+            #endregion
 
-//            context.UpdateScreenConfigurationFor(screen =>
-//            {
-//                return screen
-//                    .WithActions(actions =>
-//                    {
-//                        actions.Add(approve);
-//                        actions.Add(reject);
-//                    });
-//            });
-//        }
-//    }
-//}
+            context.UpdateScreenConfigurationFor(screen =>
+            {
+                screen
+                    .UpdateDefaultFlow(flow => flow
+                        .WithFlowStates(states =>
+                        {
+                            states
+                                .Add<State.pendingApproval>(flowState => flowState
+                                    .WithActions(actions =>
+                                    {
+                                        actions.Add(g => g.putOnHold);
+                                        actions.Add(approve, c => c
+                                            .IsDuplicatedInToolbar()
+                                            .WithConnotation(ActionConnotation.Success)
+                                            );
+                                        actions.Add(reject);
+                                    })
+                                    .WithFieldStates(fields =>
+                                    {
+                                        fields.AddAllFields<WOOrder>(c => c.IsDisabled());
+                                        fields.AddField<workOrderCD>();
+                                        fields.AddField<status>();
+                                        fields.AddAllFields<WOLine>(c => c.IsDisabled());
+                                        fields.AddAllFields<WOLineItem>(c => c.IsDisabled());
+                                        fields.AddAllFields<WOLineLabor>(c => c.IsDisabled());
+                                        fields.AddAllFields<WOLineTool>(c => c.IsDisabled());
+                                        fields.AddAllFields<WOLineMeasure>(c => c.IsDisabled());
+                                        fields.AddAllFields<WOLineFailure>(c => c.IsDisabled());
+                                    }));
+                            states
+                                .Add<State.rejected>(flowState => flowState
+                                    .WithActions(actions =>
+                                    {
+                                        actions.Add(g => g.putOnHold);
+                                    })
+                                    .WithFieldStates(fields =>
+                                    {
+                                        fields.AddAllFields<WOOrder>(c => c.IsDisabled());
+                                        fields.AddField<workOrderCD>();
+                                        fields.AddField<status>();
+                                        fields.AddAllFields<WOLine>(c => c.IsDisabled());
+                                        fields.AddAllFields<WOLineItem>(c => c.IsDisabled());
+                                        fields.AddAllFields<WOLineLabor>(c => c.IsDisabled());
+                                        fields.AddAllFields<WOLineTool>(c => c.IsDisabled());
+                                        fields.AddAllFields<WOLineMeasure>(c => c.IsDisabled());
+                                        fields.AddAllFields<WOLineFailure>(c => c.IsDisabled());
+                                    }));
+                            states
+                                .Add<State.approved>(flowState => flowState
+                                    .WithActions(actions =>
+                                    {
+                                        actions.Add(g => g.putOnHold);
+                                        actions.Add(g => g.complete, c => c.IsDuplicatedInToolbar());
+                                    })
+                                    .WithFieldStates(fields =>
+                                    {
+                                        fields.AddAllFields<WOOrder>(c => c.IsDisabled());
+                                        fields.AddField<workOrderCD>();
+                                        fields.AddField<status>();
+                                        fields.AddAllFields<WOLine>(c => c.IsDisabled());
+                                        fields.AddAllFields<WOLineItem>(c => c.IsDisabled());
+                                        fields.AddAllFields<WOLineLabor>(c => c.IsDisabled());
+                                        fields.AddAllFields<WOLineTool>(c => c.IsDisabled());
+                                        fields.AddAllFields<WOLineMeasure>(c => c.IsDisabled());
+                                        fields.AddAllFields<WOLineFailure>(c => c.IsDisabled());
+                                    }));
+                        })
+                        #region AutoAction - Add the action to the state and then Updated it like this example
+                        //.WithFlowStates(states =>
+                        //{
+                        //    states
+                        //        .Update<State.approved>(flowState => flowState
+                        //            .WithActions(actions =>
+                        //            {
+                        //                actions.Update(g => g.myAutoAction, a => a.IsAutoAction());
+                        //            }));
+                        //})
+                        #endregion
+                        .WithTransitions(transitions =>
+                        {
+                            transitions
+                                .UpdateGroupFrom(State.InitialState, ts =>
+                                {
+                                    ts.Add(t => t
+                                        .To<State.rejected>()
+                                        .IsTriggeredOn(g => g.initializeState)
+                                        .When(conditions.IsRejected)
+                                        .PlaceAfter(tr => tr.To<State.hold>()));
+                                    ts.Add(t => t
+                                        .To<State.approved>()
+                                        .IsTriggeredOn(g => g.initializeState)
+                                        .When(conditions.IsApproved)
+                                        .PlaceAfter(tr => tr.To<State.rejected>()));
+                                    ts.Add(t => t
+                                        .To<State.pendingApproval>()
+                                        .IsTriggeredOn(g => g.initializeState)
+                                        .When(!conditions.IsApproved)
+                                        .PlaceAfter(tr => tr.To<State.approved>()));
+                                });
+
+                            transitions.UpdateGroupFrom<State.hold>(ts =>
+                            {
+                                ts.Add(t => t
+                                    .To<State.pendingApproval>()
+                                    .IsTriggeredOn(g => g.removeHold)
+                                    .When(conditions.ApprovalRequired)
+                                    .PlaceBefore(tr => tr.To<State.pendingSchedule>())
+                                    .WithFieldAssignments(fas => fas.Add<hold>(false))
+                                );
+                            });
+
+                            transitions
+                                .AddGroupFrom<State.pendingApproval>(ts =>
+                                {
+                                    ts.Add(t => t
+                                        .To<State.pendingSchedule>()
+                                        .IsTriggeredOn(approve)
+                                        .When(conditions.IsApproved));
+
+                                    ts.Add(t => t
+                                        .To<State.rejected>()
+                                        .IsTriggeredOn(reject)
+                                        .When(conditions.IsRejected));
+
+                                    ts.Add(t => t
+                                        .To<State.hold>()
+                                        .IsTriggeredOn(g => g.putOnHold)
+                                        .When(conditions.IsOnHold));
+                                });
+
+                            transitions
+                                .AddGroupFrom<State.rejected>(ts =>
+                                {
+                                    ts.Add(t => t
+                                        .To<State.hold>()
+                                        .IsTriggeredOn(g => g.putOnHold)
+                                        .When(conditions.IsOnHold));
+                                });
+
+                            transitions
+                                .AddGroupFrom<State.approved>(ts =>
+                                {
+                                    ts.Add(t => t
+                                        .To<State.hold>()
+                                        .IsTriggeredOn(g => g.putOnHold)
+                                        .When(conditions.IsOnHold));
+                                    ts.Add(t => t
+                                        .To<State.complete>()
+                                        .IsTriggeredOn(g => g.complete));
+                                });
+                        })
+                        );
+
+                screen
+                    .WithActions(actions =>
+                    {
+                        actions.Add(approve);
+                        actions.Add(reject);
+                    });
+                return screen;
+            });
+        }
+    }
+}

--- a/CMMS/Graph/Entry/Workflow/WOOrderEntry_Workflow.cs
+++ b/CMMS/Graph/Entry/Workflow/WOOrderEntry_Workflow.cs
@@ -48,8 +48,12 @@ namespace CMMSlite.WO
                     = Bql<hold.IsEqual<True>>(),
                 IsPendingSchedule
                     = Bql<status.IsEqual<State.pendingSchedule>>(),
+                IsScheduled
+                    = Bql<status.IsEqual<State.scheduled>>(),
                 IsOpen
                     = Bql<status.IsEqual<State.open>>(),
+                IsComplete
+                    = Bql<status.IsEqual<State.complete>>(),
                 HasRequiredFields
                     = Bql<wOClassID.IsNotNull>(),
             }.AutoNameConditions();
@@ -131,7 +135,6 @@ namespace CMMSlite.WO
                                 {
                                     fields.AddAllFields<WOOrder>(c => c.IsDisabled());
                                     fields.AddField<workOrderCD>();
-                                    fields.AddField<status>();
                                     fields.AddAllFields<WOLine>(c => c.IsDisabled());
                                     fields.AddAllFields<WOLineItem>(c => c.IsDisabled());
                                     fields.AddAllFields<WOLineLabor>(c => c.IsDisabled());
@@ -155,7 +158,6 @@ namespace CMMSlite.WO
                                 {
                                     fields.AddAllFields<WOOrder>(c => c.IsDisabled());
                                     fields.AddField<workOrderCD>();
-                                    fields.AddField<status>();
                                     fields.AddAllFields<WOLine>(c => c.IsDisabled());
                                     fields.AddAllFields<WOLineItem>(c => c.IsDisabled());
                                     fields.AddAllFields<WOLineLabor>(c => c.IsDisabled());
@@ -180,7 +182,6 @@ namespace CMMSlite.WO
                                 {
                                     fields.AddAllFields<WOOrder>(c => c.IsDisabled());
                                     fields.AddField<workOrderCD>();
-                                    fields.AddField<status>();
                                     fields.AddAllFields<WOLine>(c => c.IsDisabled());
                                     fields.AddAllFields<WOLineItem>();
                                     fields.AddAllFields<WOLineLabor>();
@@ -220,6 +221,22 @@ namespace CMMSlite.WO
                                     .To<State.hold>()
                                     .IsTriggeredOn(g => g.initializeState)
                                     .When(conditions.IsOnHold));
+                                ts.Add(t => t
+                                    .To<State.pendingSchedule>()
+                                    .IsTriggeredOn(g => g.initializeState)
+                                    .When(conditions.IsPendingSchedule));
+                                ts.Add(t => t
+                                    .To<State.scheduled>()
+                                    .IsTriggeredOn(g => g.initializeState)
+                                    .When(conditions.IsScheduled));
+                                ts.Add(t => t
+                                    .To<State.open>()
+                                    .IsTriggeredOn(g => g.initializeState)
+                                    .When(conditions.IsOpen));
+                                ts.Add(t => t
+                                    .To<State.complete>()
+                                    .IsTriggeredOn(g => g.initializeState)
+                                    .When(conditions.IsComplete));
                             });
 
                             // Hold
@@ -228,6 +245,7 @@ namespace CMMSlite.WO
                                 ts.Add(t => t
                                     .To<State.pendingSchedule>()
                                     .IsTriggeredOn(g => g.removeHold)
+                                    .When(!conditions.IsOnHold)
                                     );
                             });
 

--- a/CMMS/Graph/Maintenance/WOClassMaint.cs
+++ b/CMMS/Graph/Maintenance/WOClassMaint.cs
@@ -1,6 +1,8 @@
 ﻿using PX.Data;
 using PX.Data.BQL.Fluent;
+using PX.Data.Descriptor;
 using PX.Objects.CR;
+using CS = PX.Objects.CS;
 
 namespace CMMSlite.WO
 {

--- a/CMMS/Graph/Maintenance/WOClassMaint.cs
+++ b/CMMS/Graph/Maintenance/WOClassMaint.cs
@@ -1,5 +1,6 @@
 ﻿using PX.Data;
 using PX.Data.BQL.Fluent;
+using PX.Objects.CR;
 
 namespace CMMSlite.WO
 {
@@ -7,5 +8,9 @@ namespace CMMSlite.WO
     {
         [PXViewName(Messages.ViewClasses)]
         public SelectFrom<WOClass>.View Classes;
+
+        [PXViewName(PX.Objects.CR.Messages.Attributes)]
+        public CSAttributeGroupList<WOClass.wOClassID, WOOrder> Mapping;
+
     }
 }

--- a/CMMS/Graph/Setup/WOSetupMaint.cs
+++ b/CMMS/Graph/Setup/WOSetupMaint.cs
@@ -11,14 +11,26 @@ namespace CMMSlite.WO
 {
     public class WOSetupMaint : PXGraph<WOSetupMaint>
     {
+        public PXSave<WOSetup> Save;
+        public PXCancel<WOSetup> Cancel;
+
         [PXViewName(Messages.ViewPreferences)]
         public SelectFrom<WOSetup>.View Preferences;
 
         [PXViewName(Messages.ViewSetupApproval)]
-        public SelectFrom<WOSetupApproval>.View Approvals;
+        public SelectFrom<WOSetupApproval>.View SetupApproval;
 
-        public PXSave<WOSetup> Save;
-        public PXCancel<WOSetup> Cancel;
+        #region Event Handlers
+        protected virtual void _(Events.FieldUpdated<WOSetup.wORequestApproval> e)
+        {
+            PXCache cache = this.Caches[typeof(WOSetupApproval)];
+            foreach (WOSetupApproval setup in PXSelect<WOSetupApproval>.Select(this))
+            {
+                setup.IsActive = (bool?)e.NewValue;
+                cache.Update(setup);
+            }
+        }
+        #endregion
 
     }
 }

--- a/CMMS/Graph/Setup/WOSetupMaint.cs
+++ b/CMMS/Graph/Setup/WOSetupMaint.cs
@@ -1,33 +1,36 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using PX.Objects;
-using PX.Data;
+﻿using PX.Data;
 using PX.Data.BQL.Fluent;
 
 namespace CMMSlite.WO
 {
     public class WOSetupMaint : PXGraph<WOSetupMaint>
     {
+
+        #region Buttons
+
         public PXSave<WOSetup> Save;
         public PXCancel<WOSetup> Cancel;
 
+        #endregion
+
+        #region Views
+
         [PXViewName(Messages.ViewPreferences)]
-        public SelectFrom<WOSetup>.View Preferences;
+        public SelectFrom<WOSetup>.View Setup;
 
         [PXViewName(Messages.ViewSetupApproval)]
         public SelectFrom<WOSetupApproval>.View SetupApproval;
 
+        #endregion
+
         #region Event Handlers
-        protected virtual void _(Events.FieldUpdated<WOSetup.wORequestApproval> e)
+        protected virtual void _(Events.FieldUpdated<WOSetup, WOSetup.wORequestApproval> e)
         {
-            PXCache cache = this.Caches[typeof(WOSetupApproval)];
-            foreach (WOSetupApproval setup in PXSelect<WOSetupApproval>.Select(this))
+            foreach (WOSetupApproval setup in SetupApproval.Select())
             {
-                setup.IsActive = (bool?)e.NewValue;
-                cache.Update(setup);
+                setup.IsActive = e.Row.WORequestApproval;
+                
+                SetupApproval.Cache.Update(setup);
             }
         }
         #endregion

--- a/CMMS/Utility/StringReference/Messages.cs
+++ b/CMMS/Utility/StringReference/Messages.cs
@@ -87,7 +87,7 @@ namespace CMMSlite.WO
 
         public const string FieldApprovalID = "Approval ID";
         public const string FieldAssignmentMapID = "Approval Map";
-        public const string FieldAssignmentNotificationID = "Notification ID";
+        public const string FieldAssignmentNotificationID = "Pending Approval Notification";
         public const string FieldIsActive = "Active";
 
         public const string FieldEquipmentType = "Equipment Type";

--- a/CMMS/Utility/StringReference/Messages.cs
+++ b/CMMS/Utility/StringReference/Messages.cs
@@ -71,6 +71,7 @@ namespace CMMSlite.WO
         public const string FieldWorkOrderID = "Work Order ID";
         public const string FieldWorkOrderType = "Work Order Type";
         public const string FieldWOClassID = "Work Order Class";
+        public const string FieldWOClass = "Class";
         public const string FieldBranchID = "Branch";
         public const string FieldPriority = "Priority";
         public const string FieldOrigWorkOrderID = "Orig Work Order ID";

--- a/CMMS_22_111_0020/Pages/WO/WO101000.aspx
+++ b/CMMS_22_111_0020/Pages/WO/WO101000.aspx
@@ -13,34 +13,38 @@
 </asp:Content>
 <asp:Content ID="cont2" ContentPlaceHolderID="phF" Runat="Server"></asp:Content>
 <asp:Content ID="cont3" ContentPlaceHolderID="phG" Runat="Server">
-	<px:PXTab ID="tab" runat="server" Width="100%" Height="150px" DataSourceID="ds" AllowAutoHide="false">
+	<px:PXTab DataMember="Preferences" ID="tab" runat="server" Width="100%" Height="150px" DataSourceID="ds" AllowAutoHide="false">
 		<Items>
 			<px:PXTabItem Text="General">
 				<Template>
-					<px:PXFormView DataMember="Preferences" DataSourceID="ds" runat="server" ID="CstFormView1" >
-						<Template>
 							<px:PXLayoutRule runat="server" ID="CstPXLayoutRule11" StartRow="True" ControlSize="SM" LabelsWidth="S" />
 							<px:PXSelector runat="server" ID="CstPXSelector8" DataField="WONumberingID" AllowEdit="True" ></px:PXSelector>
-							<px:PXSelector AllowEdit="True" runat="server" ID="CstPXSelector10" DataField="EquipNumberingID" ></px:PXSelector></Template></px:PXFormView></Template>
+							<px:PXSelector AllowEdit="True" runat="server" ID="CstPXSelector10" DataField="EquipNumberingID" ></px:PXSelector>
+				</Template>
 			</px:PXTabItem>
 			<px:PXTabItem Text="Approval">
 				<Template>
-					<px:PXFormView DataSourceID="ds" runat="server" ID="CstFormView3" DataMember="Preferences">
-						<Template>
-							<px:PXLayoutRule runat="server" ID="CstPXLayoutRule4" StartRow="True" ></px:PXLayoutRule>
-							<px:PXCheckBox runat="server" ID="CstPXCheckBox7" DataField="WORequestApproval" /></Template>
-						<AutoSize Enabled="True" ></AutoSize>
-						<AutoSize MinHeight="30" ></AutoSize></px:PXFormView>
-					<px:PXGrid Width="100%" DataSourceID="ds" runat="server" ID="CstPXGrid2">
-						<Levels>
-							<px:PXGridLevel DataMember="Approvals" >
-								<Columns>
-									<px:PXGridColumn DataField="IsActive" Width="60" ></px:PXGridColumn>
-									<px:PXGridColumn DataField="AssignmentMapID" Width="220" ></px:PXGridColumn>
-									<px:PXGridColumn DataField="AssignmentNotificationID" Width="280" ></px:PXGridColumn></Columns></px:PXGridLevel></Levels>
-						<AutoSize Enabled="True" />
-						<AutoSize MinHeight="200" />
-						<AutoSize MinWidth="200" /></px:PXGrid></Template>
+				    <px:PXPanel runat="server">
+				        <px:PXLayoutRule runat="server" LabelsWidth="S" ControlSize="XM" ></px:PXLayoutRule>
+				        <px:PXCheckBox ID="chkRequestApproval" runat="server" AlignLeft="true" Checked="True" DataField="WORequestApproval" ></px:PXCheckBox>				        
+                    </px:PXPanel>
+                    <px:PXGrid ID="gridApproval" runat="server" DataSourceID="ds" SkinID="Details" Width="100%" >
+                        <AutoSize Enabled="true" Container="Parent" MinHeight="200"></AutoSize>
+					    <Levels>
+						    <px:PXGridLevel DataMember="SetupApproval" DataKeyNames="ApprovalID">
+							    <RowTemplate>
+								    <px:PXLayoutRule runat="server" StartColumn="True"  LabelsWidth="M" ControlSize="XM" ></px:PXLayoutRule>
+
+								    <px:PXSelector ID="edAssignmentMapID" runat="server" DataField="AssignmentMapID" TextField="Name" AllowEdit="True" ></px:PXSelector>
+                                    <px:PXSelector ID="edAssignmentNotificationID" runat="server" DataField="AssignmentNotificationID" AllowEdit="True" ></px:PXSelector>
+							    </RowTemplate>
+							    <Columns>
+								<px:PXGridColumn DataField="AssignmentMapID" Width="220" ></px:PXGridColumn>
+                                    <px:PXGridColumn DataField="AssignmentNotificationID" Width="250px" RenderEditorText="True"  ></px:PXGridColumn></Columns>
+						    </px:PXGridLevel>
+					    </Levels>                        
+					</px:PXGrid>
+                </Template>
 			</px:PXTabItem>
 		</Items>
 		<AutoSize Container="Window" Enabled="True" MinHeight="150" />

--- a/CMMS_22_111_0020/Pages/WO/WO101000.aspx
+++ b/CMMS_22_111_0020/Pages/WO/WO101000.aspx
@@ -1,52 +1,49 @@
-<%@ Page Language="C#" MasterPageFile="~/MasterPages/FormTab.master" AutoEventWireup="true" ValidateRequest="false" CodeFile="WO101000.aspx.cs" Inherits="Page_WO101000" Title="Untitled Page" %>
-<%@ MasterType VirtualPath="~/MasterPages/FormTab.master" %>
+<%@ Page Language="C#" MasterPageFile="~/MasterPages/FormView.master" AutoEventWireup="True" ValidateRequest="False" CodeFile="WO101000.aspx.cs" Inherits="Page_WO101000" Title="Untitled Page" %>
 
-<asp:Content ID="cont1" ContentPlaceHolderID="phDS" Runat="Server">
-	<px:PXDataSource ID="ds" runat="server" Visible="True" Width="100%"
-        TypeName="CMMSlite.WO.WOSetupMaint"
-        PrimaryView="Preferences"
-        >
-		<CallbackCommands>
+<%@ MasterType VirtualPath="~/MasterPages/FormView.master" %>
 
-		</CallbackCommands>
-	</px:PXDataSource>
+<asp:Content ID="cont1" ContentPlaceHolderID="phDS" runat="Server">
+    <px:PXDataSource ID="ds" runat="server" Visible="True" Width="100%" TypeName="CMMSlite.WO.WOSetupMaint" PrimaryView="Setup" Height="36px" />
 </asp:Content>
-<asp:Content ID="cont2" ContentPlaceHolderID="phF" Runat="Server"></asp:Content>
-<asp:Content ID="cont3" ContentPlaceHolderID="phG" Runat="Server">
-	<px:PXTab DataMember="Preferences" ID="tab" runat="server" Width="100%" Height="150px" DataSourceID="ds" AllowAutoHide="false">
-		<Items>
-			<px:PXTabItem Text="General">
-				<Template>
-							<px:PXLayoutRule runat="server" ID="CstPXLayoutRule11" StartRow="True" ControlSize="SM" LabelsWidth="S" />
-							<px:PXSelector runat="server" ID="CstPXSelector8" DataField="WONumberingID" AllowEdit="True" ></px:PXSelector>
-							<px:PXSelector AllowEdit="True" runat="server" ID="CstPXSelector10" DataField="EquipNumberingID" ></px:PXSelector>
-				</Template>
-			</px:PXTabItem>
-			<px:PXTabItem Text="Approval">
-				<Template>
-				    <px:PXPanel runat="server">
-				        <px:PXLayoutRule runat="server" LabelsWidth="S" ControlSize="XM" ></px:PXLayoutRule>
-				        <px:PXCheckBox ID="chkRequestApproval" runat="server" AlignLeft="true" Checked="True" DataField="WORequestApproval" ></px:PXCheckBox>				        
-                    </px:PXPanel>
-                    <px:PXGrid ID="gridApproval" runat="server" DataSourceID="ds" SkinID="Details" Width="100%" >
-                        <AutoSize Enabled="true" Container="Parent" MinHeight="200"></AutoSize>
-					    <Levels>
-						    <px:PXGridLevel DataMember="SetupApproval" DataKeyNames="ApprovalID">
-							    <RowTemplate>
-								    <px:PXLayoutRule runat="server" StartColumn="True"  LabelsWidth="M" ControlSize="XM" ></px:PXLayoutRule>
-
-								    <px:PXSelector ID="edAssignmentMapID" runat="server" DataField="AssignmentMapID" TextField="Name" AllowEdit="True" ></px:PXSelector>
-                                    <px:PXSelector ID="edAssignmentNotificationID" runat="server" DataField="AssignmentNotificationID" AllowEdit="True" ></px:PXSelector>
-							    </RowTemplate>
-							    <Columns>
-								<px:PXGridColumn DataField="AssignmentMapID" Width="220" ></px:PXGridColumn>
-                                    <px:PXGridColumn DataField="AssignmentNotificationID" Width="250px" RenderEditorText="True"  ></px:PXGridColumn></Columns>
-						    </px:PXGridLevel>
-					    </Levels>                        
-					</px:PXGrid>
+<asp:Content ID="cont2" ContentPlaceHolderID="phF" runat="Server">
+    <px:PXTab ID="tab" runat="server" DataSourceID="ds" Height="150px" Style="z-index: 100" Width="100%" DataMember="Setup" SyncPosition="True">
+        <Items>
+            <px:PXTabItem Text="General Settings">
+                <Template>
+                    <px:PXLayoutRule runat="server" StartRow="True" LabelsWidth="M" />
+                    <px:PXLayoutRule runat="server" GroupCaption="Work Order Process" />
+                    <px:PXLayoutRule runat="server" ID="CstPXLayoutRule11" StartRow="True" ControlSize="SM" LabelsWidth="S" />
+                    <px:PXSelector runat="server" ID="CstPXSelector8" DataField="WONumberingID" AllowEdit="True"></px:PXSelector>
+                    <px:PXSelector AllowEdit="True" runat="server" ID="CstPXSelector10" DataField="EquipNumberingID"></px:PXSelector>
+                    <px:PXLayoutRule runat="server" StartRow="True" LabelsWidth="M" />
                 </Template>
-			</px:PXTabItem>
-		</Items>
-		<AutoSize Container="Window" Enabled="True" MinHeight="150" />
-	</px:PXTab>
+            </px:PXTabItem>
+            <px:PXTabItem Text="Approvals">
+                <Template>
+                    <px:PXPanel ID="PXPanel1" runat="server" DataMember="">
+                        <px:PXLayoutRule runat="server" LabelsWidth="S" ControlSize="XM" />
+                        <px:PXCheckBox ID="chkWORequestApproval" runat="server" AlignLeft="True" Checked="True" DataField="WORequestApproval" CommitChanges="True" />
+                    </px:PXPanel>
+                    <px:PXGrid ID="grdApproval" runat="server" Height="400px" Width="100%" Style="z-index: 100" AllowPaging="True" AdjustPageSize="Auto" DataSourceID="ds" SkinID="DetailsInTab" TabIndex="2500" SyncPosition="True">
+                        <Levels>
+                            <px:PXGridLevel DataKeyNames="ApprovalID" DataMember="SetupApproval">
+                                <RowTemplate>
+                                    <px:PXCheckBox ID="edIsActive" runat="server" DataField="IsActive" CommitChanges="True" />
+                                    <px:PXSelector ID="edAssignmentMapID" runat="server" DataField="AssignmentMapID" CommitChanges="True" />
+                                    <px:PXSelector ID="edAssignmentNotificationID" runat="server" DataField="AssignmentNotificationID" CommitChanges="True" />
+                                </RowTemplate>
+                                <Columns>
+                                    <px:PXGridColumn DataField="IsActive" TextAlign="Center" Type="CheckBox" Width="60px" />
+                                    <px:PXGridColumn DataField="AssignmentMapID" TextAlign="Right" />
+                                    <px:PXGridColumn DataField="AssignmentNotificationID" Width="280px" />
+                                </Columns>
+                            </px:PXGridLevel>
+                        </Levels>
+                        <AutoSize Container="Window" Enabled="True" MinHeight="200" />
+                    </px:PXGrid>
+                </Template>
+            </px:PXTabItem>
+        </Items>
+        <AutoSize Container="Window" Enabled="True" MinHeight="200" />
+    </px:PXTab>
 </asp:Content>

--- a/CMMS_22_111_0020/Pages/WO/WO201000.aspx
+++ b/CMMS_22_111_0020/Pages/WO/WO201000.aspx
@@ -1,22 +1,58 @@
-<%@ Page Language="C#" MasterPageFile="~/MasterPages/FormView.master" AutoEventWireup="true" ValidateRequest="false" CodeFile="WO201000.aspx.cs" Inherits="Page_WO201000" Title="Untitled Page" %>
-<%@ MasterType VirtualPath="~/MasterPages/FormView.master" %>
+<%@ Page Language="C#" MasterPageFile="~/MasterPages/TabView.master" AutoEventWireup="true" ValidateRequest="false" CodeFile="WO201000.aspx.cs" Inherits="Page_WO201000" Title="Untitled Page" %>
+<%@ MasterType VirtualPath="~/MasterPages/TabView.master" %>
 
 <asp:Content ID="cont1" ContentPlaceHolderID="phDS" Runat="Server">
-	<px:PXDataSource ID="ds" runat="server" Visible="True" Width="100%"
+	<px:PXDataSource EnableAttributes="True" ID="ds" runat="server" Visible="True" Width="100%"
         TypeName="CMMSlite.WO.WOClassMaint"
         PrimaryView="Classes"
         >
 		<CallbackCommands>
-
+			<px:PXDSCallbackCommand CommitChanges="True" Name="Save" ></px:PXDSCallbackCommand>
 		</CallbackCommands>
 	</px:PXDataSource>
 </asp:Content>
-<asp:Content ID="cont2" ContentPlaceHolderID="phF" Runat="Server">
-	<px:PXFormView Height="130px" ID="form" runat="server" DataSourceID="ds" DataMember="Classes" Width="100%" AllowAutoHide="false">
-		<Template>
-			<px:PXLayoutRule ControlSize="SM" LabelsWidth="S" ID="PXLayoutRule1" runat="server" StartRow="True"></px:PXLayoutRule>
-			<px:PXSelector runat="server" ID="CstPXSelector2" DataField="WOClassID" ></px:PXSelector>
-			<px:PXTextEdit runat="server" ID="CstPXTextEdit1" DataField="Descr" ></px:PXTextEdit></Template>
-		<AutoSize Container="Window" Enabled="True" MinHeight="200" ></AutoSize>
-	</px:PXFormView>
+<asp:Content ID="cont3" ContentPlaceHolderID="phF" Runat="Server">
+    <px:PXTab ID="tab" runat="server" DataSourceID="ds" Height="559px" Style="z-index: 100" Width="100%" Caption="NCM Class">
+        <Items>
+            <px:PXTabItem Text="General Settings">
+                <Template>
+
+					<px:PXFormView Height="130px" ID="form" runat="server" DataSourceID="ds" DataMember="Classes" Width="100%" AllowAutoHide="false">
+						<Template>
+							<px:PXLayoutRule ControlSize="SM" LabelsWidth="S" ID="PXLayoutRule1" runat="server" StartRow="True"></px:PXLayoutRule>
+							<px:PXSelector runat="server" ID="CstPXSelector2" DataField="WOClassID" ></px:PXSelector>
+							<px:PXTextEdit runat="server" ID="CstPXTextEdit1" DataField="Descr" ></px:PXTextEdit></Template>
+						<AutoSize Container="Window" Enabled="True" MinHeight="200" ></AutoSize>
+					</px:PXFormView>
+
+				</Template>
+			</px:PXTabItem>
+			<px:PXTabItem Text="Attributes">
+			  <Template>
+				<px:PXGrid runat="server" BorderWidth="0px" Height="150px" SkinID="Details" Width="100%" ID="AttributesGrid" 
+							MatrixMode="True" DataSourceID="ds">
+					<AutoSize Enabled="True" Container="Window" MinHeight="150" ></AutoSize>
+					<Levels>
+						<px:PXGridLevel DataMember="Mapping">
+							<RowTemplate>
+								<px:PXSelector runat="server" DataField="AttributeID" FilterByAllFields="True" AllowEdit="True" 
+												CommitChanges="True" ID="edAttributeID" ></px:PXSelector></RowTemplate>
+							<Columns>
+								<px:PXGridColumn DataField="AttributeID" Width="81px" AutoCallBack="True" LinkCommand="ShowDetails" ></px:PXGridColumn>
+								<px:PXGridColumn DataField="Description" Width="351px" AllowNull="False" ></px:PXGridColumn>
+								<px:PXGridColumn DataField="SortOrder" TextAlign="Right" Width="81px" ></px:PXGridColumn>
+								<px:PXGridColumn DataField="Required" Type="CheckBox" TextAlign="Center" AllowNull="False" ></px:PXGridColumn>
+								<px:PXGridColumn DataField="CSAttribute__IsInternal" Type="CheckBox" TextAlign="Center" AllowNull="True" ></px:PXGridColumn>
+								<px:PXGridColumn DataField="ControlType" Type="DropDownList" Width="81px" AllowNull="False" ></px:PXGridColumn>
+								<px:PXGridColumn DataField="DefaultValue" RenderEditorText="False" Width="100px" AllowNull="True" ></px:PXGridColumn>
+							</Columns>
+						</px:PXGridLevel>
+					</Levels>
+				
+				<Mode InitNewRow="True" /></px:PXGrid>
+			  </Template>
+			</px:PXTabItem>            
+        </Items>
+        <AutoSize Enabled="true" Container="Window" />
+    </px:PXTab>
 </asp:Content>

--- a/CMMS_22_111_0020/Pages/WO/WO201000.aspx
+++ b/CMMS_22_111_0020/Pages/WO/WO201000.aspx
@@ -1,5 +1,5 @@
-<%@ Page Language="C#" MasterPageFile="~/MasterPages/TabView.master" AutoEventWireup="true" ValidateRequest="false" CodeFile="WO201000.aspx.cs" Inherits="Page_WO201000" Title="Untitled Page" %>
-<%@ MasterType VirtualPath="~/MasterPages/TabView.master" %>
+<%@ Page Language="C#" MasterPageFile="~/MasterPages/FormTab.master" AutoEventWireup="true" ValidateRequest="false" CodeFile="WO201000.aspx.cs" Inherits="Page_WO201000" Title="Untitled Page" %>
+<%@ MasterType VirtualPath="~/MasterPages/FormTab.master" %>
 
 <asp:Content ID="cont1" ContentPlaceHolderID="phDS" Runat="Server">
 	<px:PXDataSource EnableAttributes="True" ID="ds" runat="server" Visible="True" Width="100%"
@@ -11,22 +11,21 @@
 		</CallbackCommands>
 	</px:PXDataSource>
 </asp:Content>
-<asp:Content ID="cont3" ContentPlaceHolderID="phF" Runat="Server">
+<asp:Content ID="cont2" ContentPlaceHolderID="phF" runat="Server">
+    <px:PXFormView ID="form" runat="server" Width="100%" Caption="Work Order Class Summary" DataSourceID="ds" NoteIndicator="True"
+        FilesIndicator="True" ActivityIndicator="True" ActivityField="NoteActivity" DataMember="Classes" DefaultControlID="edVendorClassID"
+        TemplateContainer="">
+        <Activity HighlightColor="" SelectedColor="" Width="" Height=""></Activity>
+        <Template>
+            <px:PXLayoutRule runat="server" StartColumn="True" LabelsWidth="SM" ControlSize="M" />
+            <px:PXSelector ID="edWOClassID" runat="server" DataField="WOClassID" DataSourceID="ds" />
+            <px:PXTextEdit ID="edDescr" runat="server" DataField="Descr" />
+        </Template>
+    </px:PXFormView>
+</asp:Content>
+<asp:Content ID="cont3" ContentPlaceHolderID="phG" Runat="Server">
     <px:PXTab ID="tab" runat="server" DataSourceID="ds" Height="559px" Style="z-index: 100" Width="100%" Caption="NCM Class">
         <Items>
-            <px:PXTabItem Text="General Settings">
-                <Template>
-
-					<px:PXFormView Height="130px" ID="form" runat="server" DataSourceID="ds" DataMember="Classes" Width="100%" AllowAutoHide="false">
-						<Template>
-							<px:PXLayoutRule ControlSize="SM" LabelsWidth="S" ID="PXLayoutRule1" runat="server" StartRow="True"></px:PXLayoutRule>
-							<px:PXSelector runat="server" ID="CstPXSelector2" DataField="WOClassID" ></px:PXSelector>
-							<px:PXTextEdit runat="server" ID="CstPXTextEdit1" DataField="Descr" ></px:PXTextEdit></Template>
-						<AutoSize Container="Window" Enabled="True" MinHeight="200" ></AutoSize>
-					</px:PXFormView>
-
-				</Template>
-			</px:PXTabItem>
 			<px:PXTabItem Text="Attributes">
 			  <Template>
 				<px:PXGrid runat="server" BorderWidth="0px" Height="150px" SkinID="Details" Width="100%" ID="AttributesGrid" 

--- a/CMMS_22_111_0020/Pages/WO/WO301000.aspx
+++ b/CMMS_22_111_0020/Pages/WO/WO301000.aspx
@@ -26,11 +26,11 @@
     </px:PXFormView>
 </asp:Content>
 <asp:Content ID="cont3" ContentPlaceHolderID="phG" runat="Server">
-    <px:PXTab ID="tab1" runat="server" Style="z-index: 100;" Width="100%" DataMember="Document" SyncPosition="True">
+    <px:PXTab ID="tab1" runat="server" Style="z-index: 100;" Width="100%" DataMember="CurrentDocument" SyncPosition="True">
         <Items>
-            <px:PXTabItem Text="Details" LoadOnDemand="false" RepaintOnDemand="false">
+            <px:PXTabItem Text="Details">
                 <Template>
-<%--                    <px:PXFormView ID="form2" runat="server" Style="z-index: 100" Width="100%" DataMember="Document" CaptionVisible="False" SkinID="Transparent" DataSourceID="ds" MarkRequired="Dynamic">
+                    <px:PXFormView ID="form2" runat="server" Style="z-index: 100" Width="100%" DataMember="CurrentDocument" CaptionVisible="False" SkinID="Transparent" DataSourceID="ds" MarkRequired="Dynamic">
                         <Template>
                     <px:PXLayoutRule ControlSize="M" LabelsWidth="SM" ID="PXLayoutRule1" runat="server" StartRow="True" />
                     <px:PXSelector runat="server" ID="CstPXSelector29" DataField="OrigWorkOrderID"></px:PXSelector>
@@ -39,11 +39,11 @@
                     <px:PXSelector ID="edOwnerID" CommitChanges="true" runat="server" AutoRefresh="True" DataField="OwnerID" DataSourceID="ds" />
                       </Template>
                         <AutoSize Container="Window" Enabled="True"/>
-                        </px:PXFormView>--%>
+                        </px:PXFormView>
                 </Template>
             </px:PXTabItem>
 
-            <px:PXTabItem Text="Operations" LoadOnDemand="false" RepaintOnDemand="false">
+            <px:PXTabItem Text="Operations" LoadOnDemand="true" RepaintOnDemand="false">
                 <Template>
                     <px:PXGrid ID="gridOperations" runat="server" DataSourceID="ds" Style="z-index: 100" Height="200px" Width="100%" NoteIndicator="True" FilesIndicator="True"
                         SkinID="DetailsInTab" SyncPosition="True" SyncPositionWithGraph="True" MatrixMode="True">
@@ -60,7 +60,7 @@
                         </Levels>
                     </px:PXGrid>
 
-                    <px:PXTab ID="tab2" runat="server" Style="z-index: 100;" Width="100%" DataMember="Document" SyncPosition="True">
+                    <px:PXTab ID="tab2" runat="server" Style="z-index: 100;" Width="100%" DataMember="CurrentDocument" SyncPosition="True">
                         <Items>
                             <px:PXTabItem Text="Labor" LoadOnDemand="false" RepaintOnDemand="false">
                                 <Template>

--- a/CMMS_22_111_0020/Pages/WO/WO301000.aspx
+++ b/CMMS_22_111_0020/Pages/WO/WO301000.aspx
@@ -119,13 +119,77 @@
 						<AutoSize MinHeight="100" ></AutoSize>
 						<AutoSize Enabled="True" ></AutoSize></px:PXTab></Template>
 			</px:PXTabItem>
-			<px:PXTabItem Text="Approval">
+			<px:PXTabItem Text="Attributes">
+			  <Template>
+				<px:PXGrid runat="server" ID="PXGridAnswers" Height="200px" SkinID="Inquire" 
+							Width="100%" MatrixMode="True" DataSourceID="ds">
+					<AutoSize Enabled="True" MinHeight="200" ></AutoSize>
+					<ActionBar>
+						<Actions>
+							<Search Enabled="False" ></Search>
+						</Actions>
+					</ActionBar>
+					<Mode AllowAddNew="False" AllowDelete="False" AllowColMoving="False" ></Mode>
+					<Levels>
+						<px:PXGridLevel DataMember="Answers">                        
+							<Columns>
+								<px:PXGridColumn TextAlign="Left" DataField="AttributeID" TextField="AttributeID_description" 
+													Width="250px" AllowShowHide="False" ></px:PXGridColumn>
+								<px:PXGridColumn Type="CheckBox" TextAlign="Center" DataField="isRequired" Width="80px" ></px:PXGridColumn>
+								<px:PXGridColumn DataField="Value" Width="300px" AllowSort="False" AllowShowHide="False" ></px:PXGridColumn>
+							</Columns>
+						</px:PXGridLevel>
+					</Levels>
+				</px:PXGrid>
+			  </Template>
+			</px:PXTabItem>
+			<px:PXTabItem Text="Approvals">
 				<Template>
-					<px:PXGrid SkinID="Inquire" runat="server" ID="CstPXGrid14">
+					<px:PXGrid Caption="" SkinID="DetailsInTab" Width="100%" runat="server" ID="CstPXGridAprv" DataSourceID="ds">
 						<Levels>
-							<px:PXGridLevel ></px:PXGridLevel></Levels></px:PXGrid></Template>
+							<px:PXGridLevel DataMember="Approval" >
+								<Columns>
+									<px:PXGridColumn DataField="ApproverEmployee__AcctName" Width="160" ></px:PXGridColumn>
+									<px:PXGridColumn DataField="ApproverEmployee__AcctCD" Width="160" ></px:PXGridColumn>
+									<px:PXGridColumn DataField="ApprovedByEmployee__AcctName" Width="100" ></px:PXGridColumn>
+									<px:PXGridColumn DataField="ApprovedByEmployee__AcctCD" Width="160" ></px:PXGridColumn>
+									<px:PXGridColumn DataField="ApproveDate" Width="90" ></px:PXGridColumn>
+									<px:PXGridColumn DataField="Status" Width="90" ></px:PXGridColumn>
+									<px:PXGridColumn DataField="Reason" Width="280" ></px:PXGridColumn>
+									<px:PXGridColumn DataField="WorkgroupID" Width="150" ></px:PXGridColumn></Columns>
+								<RowTemplate>
+									<px:PXDateTimeEdit runat="server" ID="CstPXDateTimeEdit1Aprv" DataField="ApproveDate" ></px:PXDateTimeEdit>
+									<px:PXTextEdit runat="server" ID="CstPXTextEdit2Aprv" DataField="ApprovedByEmployee__AcctCD" ></px:PXTextEdit>
+									<px:PXTextEdit runat="server" ID="CstPXTextEdit3Aprv" DataField="ApprovedByEmployee__AcctName" ></px:PXTextEdit>
+									<px:PXTextEdit runat="server" ID="CstPXTextEdit4Aprv" DataField="ApproverEmployee__AcctCD" ></px:PXTextEdit>
+									<px:PXTextEdit runat="server" ID="CstPXTextEdit5Aprv" DataField="ApproverEmployee__AcctName" ></px:PXTextEdit>
+									<px:PXDropDown runat="server" ID="CstPXDropDown6Aprv" DataField="Status" ></px:PXDropDown>
+									<px:PXSelector runat="server" ID="CstPXSelector7Aprv" DataField="WorkgroupID" ></px:PXSelector>
+									<px:PXTextEdit runat="server" ID="CstPXTextEdit8Aprv" DataField="Reason" ></px:PXTextEdit></RowTemplate></px:PXGridLevel></Levels>
+						<AutoSize Container="Window" MinHeight="150" Enabled="True" ></AutoSize>
+						<Mode AllowAddNew="False" ></Mode>
+						<Mode AllowDelete="False" ></Mode>
+						<Mode AllowUpdate="False" ></Mode></px:PXGrid></Template>
 			</px:PXTabItem>
 		</Items>
 		<AutoSize Container="Window" Enabled="True" MinHeight="150" ></AutoSize>
 	</px:PXTab>
+	<px:PXSmartPanel ID="panelReason" runat="server" Caption="Enter Reason" CaptionVisible="true" LoadOnDemand="true" Key="ReasonApproveRejectParams"
+	  AutoCallBack-Enabled="true" AutoCallBack-Command="Refresh" CallBackMode-CommitChanges="True" Width="600px"
+	  CallBackMode-PostData="Page" AcceptButtonID="btnReasonOk" CancelButtonID="btnReasonCancel" AllowResize="False">
+	  <px:PXFormView ID="PXFormViewPanelReason" runat="server" DataSourceID="ds" CaptionVisible="False" DataMember="ReasonApproveRejectParams">
+		<ContentStyle BackColor="Transparent" BorderStyle="None" Width="100%" Height="100%"  CssClass="" ></ContentStyle> 
+		<Template>
+		  <px:PXLayoutRule ID="PXLayoutRulePanelReason" runat="server" StartColumn="True" ></px:PXLayoutRule>
+		  <px:PXPanel ID="PXPanelReason" runat="server" RenderStyle="Simple" >
+			<px:PXLayoutRule ID="PXLayoutRuleReason" runat="server" StartColumn="True" SuppressLabel="True" ></px:PXLayoutRule>
+			<px:PXTextEdit ID="edReason" runat="server" DataField="Reason" TextMode="MultiLine" LabelWidth="0" Height="200px" Width="600px" CommitChanges="True" ></px:PXTextEdit>
+		  </px:PXPanel>
+		  <px:PXPanel ID="PXPanelReasonButtons" runat="server" SkinID="Buttons">
+			<px:PXButton ID="btnReasonOk" runat="server" Text="OK" DialogResult="Yes" CommandSourceID="ds" ></px:PXButton>
+			<px:PXButton ID="btnReasonCancel" runat="server" Text="Cancel" DialogResult="No" CommandSourceID="ds" ></px:PXButton>
+		  </px:PXPanel>
+		</Template>
+	  </px:PXFormView>
+	</px:PXSmartPanel>
 </asp:Content>

--- a/CMMS_22_111_0020/Pages/WO/WO301000.aspx
+++ b/CMMS_22_111_0020/Pages/WO/WO301000.aspx
@@ -1,253 +1,159 @@
 <%@ Page Language="C#" MasterPageFile="~/MasterPages/FormTab.master" AutoEventWireup="true" ValidateRequest="false" CodeFile="WO301000.aspx.cs" Inherits="Page_WO301000" Title="Untitled Page" %>
+
 <%@ MasterType VirtualPath="~/MasterPages/FormTab.master" %>
 
-<asp:Content ID="cont1" ContentPlaceHolderID="phDS" Runat="Server">
-	<px:PXDataSource ID="ds" runat="server" Visible="True" Width="100%"
-        TypeName="CMMSlite.WO.WOOrderEntry"
-        PrimaryView="Document"
-        >
-		<CallbackCommands>
-
-		</CallbackCommands>
-	</px:PXDataSource>
+<asp:Content ID="cont1" ContentPlaceHolderID="phDS" runat="Server">
+    <px:PXDataSource ID="ds" runat="server" Visible="True" Width="100%" TypeName="CMMSlite.WO.WOOrderEntry" PrimaryView="Document">
+    </px:PXDataSource>
 </asp:Content>
-<asp:Content ID="cont2" ContentPlaceHolderID="phF" Runat="Server">
-	<px:PXFormView ID="form" runat="server" DataSourceID="ds" DataMember="Document" Width="100%" Height="185px" AllowAutoHide="false">
-		<Template>
-			<px:PXLayoutRule ControlSize="SM" LabelsWidth="S" ID="PXLayoutRule1" runat="server" StartRow="True"></px:PXLayoutRule>
-			<px:PXLayoutRule runat="server" ID="CstPXLayoutRule9" StartColumn="True" ></px:PXLayoutRule>
-			<px:PXDropDown runat="server" ID="CstPXDropDown22" DataField="WorkOrderType" ></px:PXDropDown>
-			<px:PXSelector runat="server" ID="CstPXSelector7" DataField="WorkOrderCD" ></px:PXSelector>
-			<px:PXDropDown runat="server" ID="CstPXDropDown5" DataField="Status" ></px:PXDropDown>
-			<px:PXDateTimeEdit runat="server" ID="CstPXDateTimeEdit27" DataField="RequestDate" ></px:PXDateTimeEdit>
-			<px:PXDateTimeEdit runat="server" ID="CstPXDateTimeEdit28" DataField="ScheduleDate" ></px:PXDateTimeEdit>
-			<px:PXLayoutRule runat="server" ID="CstLayoutRule12" ColumnSpan="2" ></px:PXLayoutRule>
-			<px:PXTextEdit runat="server" ID="CstPXTextEdit1" DataField="Descr" ></px:PXTextEdit>
-			<px:PXLayoutRule runat="server" ID="CstPXLayoutRule10" StartColumn="True" ></px:PXLayoutRule>
-			<px:PXDropDown runat="server" ID="CstPXDropDown4" DataField="Priority" ></px:PXDropDown>
-			<px:PXSelector runat="server" CommitChanges="True" ID="CstPXSelector8" DataField="WOClassID"></px:PXSelector>
-			<px:PXSelector runat="server" ID="CstPXSelector21" DataField="EquipmentID" ></px:PXSelector>
-			<px:PXSelector runat="server" ID="CstPXSelector3" DataField="OwnerID" ></px:PXSelector>
-			<px:PXSelector runat="server" ID="CstPXSelector6" DataField="WorkgroupID" ></px:PXSelector></Template>
-	
-		</px:PXFormView>
+<asp:Content ID="cont2" ContentPlaceHolderID="phF" runat="Server">
+    <px:PXFormView ID="form" runat="server" DataSourceID="ds" DataMember="Document" Width="100%">
+        <Template>
+            <px:PXLayoutRule runat="server" StartRow="True" />
+            <px:PXDropDown runat="server" ID="CstPXDropDown22" DataField="WorkOrderType" CommitChanges="true" />
+            <px:PXSelector runat="server" ID="CstPXSelector7" DataField="WorkOrderCD" />
+            <px:PXDropDown runat="server" ID="CstPXDropDown5" DataField="Status" />
+            <px:PXLabel runat="server" />
+            <px:PXDateTimeEdit runat="server" ID="CstPXDateTimeEdit27" DataField="RequestDate" CommitChanges="true" />
+            <px:PXDateTimeEdit runat="server" ID="CstPXDateTimeEdit28" DataField="ScheduleDate" CommitChanges="true" />
+            <px:PXLayoutRule runat="server" ID="CstLayoutRule12" ColumnSpan="2" />
+            <px:PXTextEdit runat="server" ID="CstPXTextEdit1" DataField="Descr" />
+            <px:PXLayoutRule runat="server" ControlSize="XM" LabelsWidth="S" StartColumn="True" />
+            <px:PXSelector runat="server" ID="CstPXSelector21" DataField="EquipmentID" />
+            <px:PXSelector runat="server" CommitChanges="True" ID="CstPXSelector8" DataField="WOClassID" />
+            <px:PXDropDown runat="server" ID="CstPXDropDown4" DataField="Priority" />
+        </Template>
+    </px:PXFormView>
 </asp:Content>
-<asp:Content ID="cont3" ContentPlaceHolderID="phG" Runat="Server">
-	<px:PXTab DataMember="CurrentDocument" ID="tab" runat="server" Width="100%" DataSourceID="ds" AllowAutoHide="false">
-		<Items>
-			<px:PXTabItem Text="Details">
-						<Template>
-							<px:PXLayoutRule ControlSize="SM" LabelsWidth="S" ID="PXLayoutRule1" runat="server" StartRow="True"></px:PXLayoutRule>
-							<px:PXLayoutRule ControlSize="SM" LabelsWidth="S" runat="server" ID="CstPXLayoutRule24" StartRow="True" ></px:PXLayoutRule>
-							<px:PXLayoutRule runat="server" ID="CstPXLayoutRule25" StartColumn="True" ></px:PXLayoutRule>
-							<px:PXSelector runat="server" ID="CstPXSelector29" DataField="OrigWorkOrderID" ></px:PXSelector></Template>
-			</px:PXTabItem>
+<asp:Content ID="cont3" ContentPlaceHolderID="phG" runat="Server">
+    <px:PXTab ID="tab1" runat="server" Style="z-index: 100;" Width="100%" DataMember="Document" SyncPosition="True">
+        <Items>
+            <px:PXTabItem Text="Details" LoadOnDemand="false" RepaintOnDemand="false">
+                <Template>
+                    <px:PXFormView ID="form2" runat="server" Style="z-index: 100" Width="100%" DataMember="Document" CaptionVisible="False" SkinID="Transparent" DataSourceID="ds" MarkRequired="Dynamic">
+                        <Template>
+                    <px:PXLayoutRule ControlSize="M" LabelsWidth="SM" ID="PXLayoutRule1" runat="server" StartRow="True" />
+                    <px:PXSelector runat="server" ID="CstPXSelector29" DataField="OrigWorkOrderID"></px:PXSelector>
+                    <px:PXLayoutRule runat="server" ControlSize="M" GroupCaption="Assigned To" LabelsWidth="SM" StartGroup="True" />
+                    <px:PXSelector ID="edWorkgroupID" CommitChanges="true" runat="server" AutoRefresh="True" DataField="WorkgroupID" DataSourceID="ds" />
+                    <px:PXSelector ID="edOwnerID" CommitChanges="true" runat="server" AutoRefresh="True" DataField="OwnerID" DataSourceID="ds" />
+                      </Template>
+                        <AutoSize Container="Window" Enabled="True"/>
+                        </px:PXFormView>
+                </Template>
+            </px:PXTabItem>
 
-			<px:PXTabItem Text="Operations">
-				<Template>
-					<px:PXSplitContainer runat="server" ID="sp1" SplitterPosition="200" SkinID="Horizontal" Height="600px" Panel1MinSize="100" Panel2MinSize="100">
-					<AutoSize Container="Window" Enabled="True" MinHeight="300" />
-					<Template1>
-						<px:PXGrid ID="grid" runat="server" DataSourceID="ds" Width="100%" Height="100%" SkinID="Details" Caption="Operations" AutoAdjustColumns="True" SyncPosition="true">
-							<Levels>
-								<px:PXGridLevel DataMember="Transactions" >
-									<Columns>
-										<px:PXGridColumn DataField="Descr" Width="400" ></px:PXGridColumn>
-										<px:PXGridColumn CommitChanges="True" DataField="EquipmentID" Width="70" ></px:PXGridColumn>
-										<px:PXGridColumn DataField="WOEquipment__Descr" Width="280" ></px:PXGridColumn></Columns>
-									<RowTemplate>
-										<px:PXSelector runat="server" ID="CstPXSelector23" DataField="EquipmentID" AllowEdit="True" ></px:PXSelector>
-									</RowTemplate>
-								</px:PXGridLevel>
-							</Levels>
-							<Mode InitNewRow="True" AllowUpload="True" />
-							<AutoSize Container="Window" Enabled="True" MinHeight="150" ></AutoSize>
-							<ActionBar ActionsText="False">
-							</ActionBar>
-							<AutoCallBack Command="Refresh" Target="gridLabor" ActiveBehavior="true" >
-								<Behavior RepaintControlsIDs="gridLabor,gridMatl,gridTool,gridMeasure,gridFailure"  />
-							</AutoCallBack>
-						</px:PXGrid>
+            <px:PXTabItem Text="Operations" LoadOnDemand="false" RepaintOnDemand="false">
+                <Template>
+                    <px:PXGrid ID="gridOperations" runat="server" DataSourceID="ds" Style="z-index: 100" Height="200px" Width="100%" NoteIndicator="True" FilesIndicator="True"
+                        SkinID="DetailsInTab" SyncPosition="True" SyncPositionWithGraph="True" MatrixMode="True">
+                        <AutoSize Container="Window" Enabled="True" MinHeight="150" />
+                        <AutoCallBack Target="tab2" Command="Refresh"/>
+                        <Levels>
+                            <px:PXGridLevel DataMember="Transactions">
+                                <Columns>
+                                    <px:PXGridColumn DataField="EquipmentID" CommitChanges="True" Width="70" />
+                                    <px:PXGridColumn DataField="WOEquipment__Descr" Width="280" />
+                                    <px:PXGridColumn DataField="Descr" Width="400" />
+                                </Columns>
+                            </px:PXGridLevel>
+                        </Levels>
+                    </px:PXGrid>
 
-					</Template1>
-					<Template2>
+                    <px:PXTab ID="tab2" runat="server" Style="z-index: 100;" Width="100%" DataMember="Document" SyncPosition="True">
+                        <Items>
+                            <px:PXTabItem Text="Labor" LoadOnDemand="false" RepaintOnDemand="false">
+                                <Template>
+                                    <px:PXGrid ID="gridLabor" runat="server" DataSourceID="ds" Style="z-index: 100" Width="100%" NoteIndicator="True" FilesIndicator="True"
+                                        SkinID="DetailsInTab" SyncPosition="True" MatrixMode="True" >
+                                        <AutoSize Container="Parent" Enabled="True" MinHeight="150"/>
+                                        <Levels>
+                                            <px:PXGridLevel DataMember="LineLabor">
+                                                <Columns>
+                                                    <px:PXGridColumn DataField="LaborType" Width="70" />
+                                                    <px:PXGridColumn DataField="LaborHours" Width="100" />
+                                                </Columns>
+                                            </px:PXGridLevel>
+                                        </Levels>
+                                    </px:PXGrid>
+                                </Template>
+                            </px:PXTabItem>
 
-						<px:PXTab ID="tab" runat="server" Width="100%" Height="100%">
-							<Items>
-								<px:PXTabItem Text="Labor" LoadOnDemand="True" RepaintOnDemand="True">
-									<Template>
-										<px:PXGrid SkinID="DetailsInTab" Width="100%" runat="server" ID="gridLabor">
-											<Levels>
-												<px:PXGridLevel DataMember="LineLabor" >
-													<Columns>
-														<px:PXGridColumn DataField="LaborType" Width="70" ></px:PXGridColumn>
-														<px:PXGridColumn DataField="LaborHours" Width="100" ></px:PXGridColumn></Columns></px:PXGridLevel></Levels>
-											<AutoSize Enabled="True" />
-											<Mode InitNewRow="True" AllowUpload="True" />
-											<ActionBar ActionsText="False">
-											</ActionBar>
-											<AutoCallBack>
-											</AutoCallBack>
-											<Parameters>
-												<px:PXSyncGridParam ControlID="grid" />
-											</Parameters>
-										</px:PXGrid></Template></px:PXTabItem>
-								<px:PXTabItem Text="Materials" LoadOnDemand="True" RepaintOnDemand="True">
-									<Template>
-										<px:PXGrid SkinID="DetailsInTab" SyncPosition="True" DataSourceID="ds" Width="100%" runat="server" ID="gridMatl">
-											<Levels>
-												<px:PXGridLevel DataMember="LineItems" >
-													<Columns>
-														<px:PXGridColumn CommitChanges="True" DataField="InventoryID" Width="70" ></px:PXGridColumn>
-														<px:PXGridColumn DataField="InventoryID_description" Width="280" ></px:PXGridColumn>
-														<px:PXGridColumn DataField="Quantity" Width="100" ></px:PXGridColumn>
-														<px:PXGridColumn DataField="InventoryItem__BaseUnit" Width="100" ></px:PXGridColumn></Columns></px:PXGridLevel></Levels>
-											<AutoSize Enabled="True" />
-											<Mode InitNewRow="True" AllowUpload="True" />
-											<ActionBar ActionsText="False">
-											</ActionBar>
-											<AutoCallBack>
-											</AutoCallBack>
-											<Parameters>
-												<px:PXSyncGridParam ControlID="grid" />
-											</Parameters>
-											</px:PXGrid></Template></px:PXTabItem>
-								<px:PXTabItem Text="Tools" LoadOnDemand="True" RepaintOnDemand="True">
-									<Template>
-										<px:PXGrid SkinID="DetailsInTab" SyncPosition="True" DataSourceID="ds" Width="100%" runat="server" ID="gridTool">
-											<Levels>
-												<px:PXGridLevel DataMember="LineTools" >
-													<Columns>
-														<px:PXGridColumn DataField="InventoryID" Width="70" CommitChanges="True" ></px:PXGridColumn>
-														<px:PXGridColumn DataField="InventoryID_description" Width="280" ></px:PXGridColumn>
-														<px:PXGridColumn DataField="Quantity" Width="100" ></px:PXGridColumn>
-														<px:PXGridColumn DataField="BaseUnit" Width="96" ></px:PXGridColumn></Columns></px:PXGridLevel></Levels>
-											<AutoSize Enabled="True" />
-											<Mode InitNewRow="True" AllowUpload="True" />
-											<ActionBar ActionsText="False">
-											</ActionBar>
-											<AutoCallBack>
-											</AutoCallBack>
-											<Parameters>
-												<px:PXSyncGridParam ControlID="grid" />
-											</Parameters>
-											</px:PXGrid></Template></px:PXTabItem>
-								<px:PXTabItem Text="Measurements" LoadOnDemand="True" RepaintOnDemand="True">
-									<Template>
-										<px:PXGrid Width="100%" SkinID="DetailsInTab" SyncPosition="True" DataSourceID="ds" runat="server" ID="gridMeasure">
-											<Levels>
-												<px:PXGridLevel DataMember="LineMeasurements" >
-													<Columns>
-														<px:PXGridColumn DataField="MeasurementID" Width="140" ></px:PXGridColumn>
-														<px:PXGridColumn DataField="Value" Width="100" ></px:PXGridColumn></Columns></px:PXGridLevel></Levels>
-											<AutoSize Enabled="True" />
-											<ActionBar ActionsText="False">
-											</ActionBar>
-											<AutoCallBack>
-											</AutoCallBack>
-											<Parameters>
-												<px:PXSyncGridParam ControlID="grid" />
-											</Parameters>
-											</px:PXGrid></Template></px:PXTabItem>
-								<px:PXTabItem Text="Failure Modes" LoadOnDemand="True" RepaintOnDemand="True">
-									<Template>
-										<px:PXGrid Width="100%" SkinID="DetailsInTab" SyncPosition="True" DataSourceID="ds" runat="server" ID="gridFailure">
-											<Levels>
-												<px:PXGridLevel DataMember="LineFailureModes" >
-													<Columns>
-														<px:PXGridColumn CommitChanges="True" DataField="FailureModeID" Width="140" ></px:PXGridColumn>
-														<px:PXGridColumn DataField="Comment" Width="280" ></px:PXGridColumn></Columns></px:PXGridLevel></Levels>
-											<AutoSize Enabled="True" />
-											<ActionBar ActionsText="False">
-											</ActionBar>
-											<AutoCallBack>
-											</AutoCallBack>
-											<Parameters>
-												<px:PXSyncGridParam ControlID="grid" />
-											</Parameters>
-											</px:PXGrid></Template></px:PXTabItem>
-							</Items>
-							<AutoSize Enabled="True" />
-						</px:PXTab>
+                            <px:PXTabItem Text="Materials" LoadOnDemand="false" RepaintOnDemand="false">
+                                <Template>
+                                    <px:PXGrid ID="gridMaterials" runat="server" DataSourceID="ds" Style="z-index: 100"
+                                        Width="100%" SkinID="DetailsInTab" SyncPosition="True" MatrixMode="True"  NoteIndicator="True" FilesIndicator="True">
+                                        <AutoSize Container="Parent" Enabled="True" MinHeight="150"/>
+                                        <Levels>
+                                            <px:PXGridLevel DataMember="LineItems">
+                                                <Columns>
+                                                    <px:PXGridColumn DataField="InventoryID" CommitChanges="True" Width="70" />
+                                                    <px:PXGridColumn DataField="InventoryID_description" Width="280" />
+                                                    <px:PXGridColumn DataField="Quantity" Width="100" />
+                                                    <px:PXGridColumn DataField="InventoryItem__BaseUnit" Width="100" />
+                                                </Columns>
+                                            </px:PXGridLevel>
+                                        </Levels>
+                                    </px:PXGrid>
+                                </Template>
+                            </px:PXTabItem>
 
-					</Template2>
-					</px:PXSplitContainer>
-				</Template>
-			</px:PXTabItem>
+                            <px:PXTabItem Text="Tools" LoadOnDemand="false" RepaintOnDemand="false">
+                                <Template>
+                                    <px:PXGrid ID="gridTools" runat="server" DataSourceID="ds" Style="z-index: 100"
+                                        Width="100%" SkinID="DetailsInTab" SyncPosition="True" MatrixMode="True"  NoteIndicator="True" FilesIndicator="True">
+                                        <AutoSize Container="Parent" Enabled="True" MinHeight="150"/>
+                                        <Levels>
+                                            <px:PXGridLevel DataMember="LineTools">
+                                                <Columns>
+                                                    <px:PXGridColumn DataField="InventoryID" CommitChanges="True" Width="70" />
+                                                    <px:PXGridColumn DataField="InventoryID_description" Width="280" />
+                                                    <px:PXGridColumn DataField="Quantity" Width="100" />
+                                                    <px:PXGridColumn DataField="BaseUnit" Width="96" />
+                                                </Columns>
+                                            </px:PXGridLevel>
+                                        </Levels>
+                                    </px:PXGrid>
+                                </Template>
+                            </px:PXTabItem>
 
-			<px:PXTabItem Text="Attributes">
-			  <Template>
-				<px:PXGrid runat="server" ID="PXGridAnswers" Height="200px" SkinID="Inquire" 
-							Width="100%" MatrixMode="True" DataSourceID="ds">
-					<AutoSize Enabled="True" MinHeight="200" ></AutoSize>
-					<ActionBar>
-						<Actions>
-							<Search Enabled="False" ></Search>
-						</Actions>
-					</ActionBar>
-					<Mode AllowAddNew="False" AllowDelete="False" AllowColMoving="False" ></Mode>
-					<Levels>
-						<px:PXGridLevel DataMember="Answers">                        
-							<Columns>
-								<px:PXGridColumn TextAlign="Left" DataField="AttributeID" TextField="AttributeID_description" 
-													Width="250px" AllowShowHide="False" ></px:PXGridColumn>
-								<px:PXGridColumn Type="CheckBox" TextAlign="Center" DataField="isRequired" Width="80px" ></px:PXGridColumn>
-								<px:PXGridColumn DataField="Value" Width="300px" AllowSort="False" AllowShowHide="False" ></px:PXGridColumn>
-							</Columns>
-						</px:PXGridLevel>
-					</Levels>
-					<AutoSize Container="Window" MinHeight="150" Enabled="True" ></AutoSize>
-				</px:PXGrid>
-			  </Template>
-			</px:PXTabItem>
-			<px:PXTabItem Text="Approvals">
-				<Template>
-					<px:PXGrid Caption="" SkinID="DetailsInTab" Width="100%" runat="server" ID="CstPXGridAprv" DataSourceID="ds">
-						<Levels>
-							<px:PXGridLevel DataMember="Approval" >
-								<Columns>
-									<px:PXGridColumn DataField="ApproverEmployee__AcctName" Width="160" ></px:PXGridColumn>
-									<px:PXGridColumn DataField="ApproverEmployee__AcctCD" Width="160" ></px:PXGridColumn>
-									<px:PXGridColumn DataField="ApprovedByEmployee__AcctName" Width="100" ></px:PXGridColumn>
-									<px:PXGridColumn DataField="ApprovedByEmployee__AcctCD" Width="160" ></px:PXGridColumn>
-									<px:PXGridColumn DataField="ApproveDate" Width="90" ></px:PXGridColumn>
-									<px:PXGridColumn DataField="Status" Width="90" ></px:PXGridColumn>
-									<px:PXGridColumn DataField="Reason" Width="280" ></px:PXGridColumn>
-									<px:PXGridColumn DataField="WorkgroupID" Width="150" ></px:PXGridColumn></Columns>
-								<RowTemplate>
-									<px:PXDateTimeEdit runat="server" ID="CstPXDateTimeEdit1Aprv" DataField="ApproveDate" ></px:PXDateTimeEdit>
-									<px:PXTextEdit runat="server" ID="CstPXTextEdit2Aprv" DataField="ApprovedByEmployee__AcctCD" ></px:PXTextEdit>
-									<px:PXTextEdit runat="server" ID="CstPXTextEdit3Aprv" DataField="ApprovedByEmployee__AcctName" ></px:PXTextEdit>
-									<px:PXTextEdit runat="server" ID="CstPXTextEdit4Aprv" DataField="ApproverEmployee__AcctCD" ></px:PXTextEdit>
-									<px:PXTextEdit runat="server" ID="CstPXTextEdit5Aprv" DataField="ApproverEmployee__AcctName" ></px:PXTextEdit>
-									<px:PXDropDown runat="server" ID="CstPXDropDown6Aprv" DataField="Status" ></px:PXDropDown>
-									<px:PXSelector runat="server" ID="CstPXSelector7Aprv" DataField="WorkgroupID" ></px:PXSelector>
-									<px:PXTextEdit runat="server" ID="CstPXTextEdit8Aprv" DataField="Reason" ></px:PXTextEdit></RowTemplate></px:PXGridLevel></Levels>
-						<AutoSize Container="Window" MinHeight="150" Enabled="True" ></AutoSize>
-						<Mode AllowAddNew="False" ></Mode>
-						<Mode AllowDelete="False" ></Mode>
-						<Mode AllowUpdate="False" ></Mode></px:PXGrid></Template>
-			</px:PXTabItem>
-		</Items>
-		<AutoSize Container="Window" Enabled="True" MinHeight="150" />
-	</px:PXTab>
+                            <px:PXTabItem Text="Measurements" LoadOnDemand="false" RepaintOnDemand="false">
+                                <Template>
+                                    <px:PXGrid ID="gridMeasurements" runat="server" DataSourceID="ds" Style="z-index: 100"
+                                        Width="100%" SkinID="DetailsInTab" SyncPosition="True" MatrixMode="True"  NoteIndicator="True" FilesIndicator="True">
+                                        <AutoSize Container="Parent" Enabled="True" MinHeight="150"/>
+                                        <Levels>
+                                            <px:PXGridLevel DataMember="LineMeasurements">
+                                                <Columns>
+                                                    <px:PXGridColumn DataField="MeasurementID" Width="140" />
+                                                    <px:PXGridColumn DataField="Value" Width="100" />
+                                                </Columns>
+                                            </px:PXGridLevel>
+                                        </Levels>
+                                    </px:PXGrid>
+                                </Template>
+                            </px:PXTabItem>
 
-	<px:PXSmartPanel ID="panelReason" runat="server" Caption="Enter Reason" CaptionVisible="true" LoadOnDemand="true" Key="ReasonApproveRejectParams"
-	  AutoCallBack-Enabled="true" AutoCallBack-Command="Refresh" CallBackMode-CommitChanges="True" Width="600px"
-	  CallBackMode-PostData="Page" AcceptButtonID="btnReasonOk" CancelButtonID="btnReasonCancel" AllowResize="False">
-	  <px:PXFormView ID="PXFormViewPanelReason" runat="server" DataSourceID="ds" CaptionVisible="False" DataMember="ReasonApproveRejectParams">
-		<ContentStyle BackColor="Transparent" BorderStyle="None" Width="100%" Height="100%"  CssClass="" ></ContentStyle> 
-		<Template>
-		  <px:PXLayoutRule ID="PXLayoutRulePanelReason" runat="server" StartColumn="True" ></px:PXLayoutRule>
-		  <px:PXPanel ID="PXPanelReason" runat="server" RenderStyle="Simple" >
-			<px:PXLayoutRule ID="PXLayoutRuleReason" runat="server" StartColumn="True" SuppressLabel="True" ></px:PXLayoutRule>
-			<px:PXTextEdit ID="edReason" runat="server" DataField="Reason" TextMode="MultiLine" LabelWidth="0" Height="200px" Width="600px" CommitChanges="True" ></px:PXTextEdit>
-		  </px:PXPanel>
-		  <px:PXPanel ID="PXPanelReasonButtons" runat="server" SkinID="Buttons">
-			<px:PXButton ID="btnReasonOk" runat="server" Text="OK" DialogResult="Yes" CommandSourceID="ds" ></px:PXButton>
-			<px:PXButton ID="btnReasonCancel" runat="server" Text="Cancel" DialogResult="No" CommandSourceID="ds" ></px:PXButton>
-		  </px:PXPanel>
-		</Template>
-	  </px:PXFormView>
-	</px:PXSmartPanel>
+                            <px:PXTabItem Text="Failure Mode" LoadOnDemand="false" RepaintOnDemand="false">
+                                <Template>
+                                    <px:PXGrid ID="gridFailure" runat="server" DataSourceID="ds" Style="z-index: 100"
+                                        Width="100%" SkinID="DetailsInTab" SyncPosition="True" MatrixMode="True"  NoteIndicator="True" FilesIndicator="True">
+                                        <AutoSize Container="Parent" Enabled="True" MinHeight="150"/>
+                                        <Levels>
+                                            <px:PXGridLevel DataMember="LineFailureModes">
+                                                <Columns>
+                                                    <px:PXGridColumn DataField="FailureModeID" CommitChanges="True" Width="140" />
+                                                    <px:PXGridColumn DataField="Comment" Width="280" />
+                                                </Columns>
+                                            </px:PXGridLevel>
+                                        </Levels>
+                                    </px:PXGrid>
+                                </Template>
+                            </px:PXTabItem>
+                        </Items>
+                    </px:PXTab>
+                </Template>
+            </px:PXTabItem>
+        </Items>
+    </px:PXTab>
 </asp:Content>

--- a/CMMS_22_111_0020/Pages/WO/WO301000.aspx
+++ b/CMMS_22_111_0020/Pages/WO/WO301000.aspx
@@ -25,7 +25,7 @@
 			<px:PXTextEdit runat="server" ID="CstPXTextEdit1" DataField="Descr" ></px:PXTextEdit>
 			<px:PXLayoutRule runat="server" ID="CstPXLayoutRule10" StartColumn="True" ></px:PXLayoutRule>
 			<px:PXDropDown runat="server" ID="CstPXDropDown4" DataField="Priority" ></px:PXDropDown>
-			<px:PXSelector runat="server" ID="CstPXSelector8" DataField="WOClassID" ></px:PXSelector>
+			<px:PXSelector runat="server" CommitChanges="True" ID="CstPXSelector8" DataField="WOClassID"></px:PXSelector>
 			<px:PXSelector runat="server" ID="CstPXSelector21" DataField="EquipmentID" ></px:PXSelector>
 			<px:PXSelector runat="server" ID="CstPXSelector3" DataField="OwnerID" ></px:PXSelector>
 			<px:PXSelector runat="server" ID="CstPXSelector6" DataField="WorkgroupID" ></px:PXSelector></Template>
@@ -35,90 +35,131 @@
 <asp:Content ID="cont3" ContentPlaceHolderID="phG" Runat="Server">
 	<px:PXTab DataMember="CurrentDocument" ID="tab" runat="server" Width="100%" DataSourceID="ds" AllowAutoHide="false">
 		<Items>
-							<px:PXTabItem Text="Details">
-								<Template>
-									<px:PXLayoutRule ControlSize="SM" LabelsWidth="S" runat="server" ID="CstPXLayoutRule24" StartRow="True" ></px:PXLayoutRule>
-									<px:PXLayoutRule runat="server" ID="CstPXLayoutRule25" StartColumn="True" ></px:PXLayoutRule>
-									<px:PXSelector runat="server" ID="CstPXSelector29" DataField="OrigWorkOrderID" ></px:PXSelector></Template></px:PXTabItem>
-			<px:PXTabItem Text="General">
-				<Template>
-					<px:PXGrid Height="100px" SkinID="Details" SyncPosition="True" DataSourceID="ds" Width="100%" runat="server" ID="CstPXGrid13">
-						<Levels>
-							<px:PXGridLevel DataMember="Transactions" >
-								<Columns>
-									<px:PXGridColumn DataField="Descr" Width="400" ></px:PXGridColumn>
-									<px:PXGridColumn CommitChanges="True" DataField="EquipmentID" Width="70" ></px:PXGridColumn>
-									<px:PXGridColumn DataField="WOEquipment__Descr" Width="280" ></px:PXGridColumn></Columns>
-								<RowTemplate>
-									<px:PXSelector runat="server" ID="CstPXSelector23" DataField="EquipmentID" AllowEdit="True" ></px:PXSelector></RowTemplate></px:PXGridLevel></Levels>
-						<Mode InitNewRow="True" ></Mode>
-						<AutoCallBack ActiveBehavior="True" Target="CstPXGrid17" Command="Refresh" >
-							<Behavior RepaintControlsIDs="CstPXGrid17,CstPXGrid18,CstPXGrid19,CstPXGrid20" ></Behavior></AutoCallBack>
-						<AutoCallBack ActiveBehavior="True" ></AutoCallBack>
-						<AutoCallBack Target="CstPXGrid17" ></AutoCallBack></px:PXGrid>
-					<px:PXTab Width="100%" runat="server" ID="CstPXTab15">
-						<Items>
-							<px:PXTabItem Text="Labor">
-								<Template>
-									<px:PXGrid SkinID="Details" Width="100%" runat="server" ID="CstPXGrid30">
-										<Levels>
-											<px:PXGridLevel DataMember="LineLabor" >
-												<Columns>
-													<px:PXGridColumn DataField="LaborType" Width="70" ></px:PXGridColumn>
-													<px:PXGridColumn DataField="LaborHours" Width="100" ></px:PXGridColumn></Columns></px:PXGridLevel></Levels>
-										<AutoSize Enabled="True" />
-										<AutoSize MinHeight="100" /></px:PXGrid></Template></px:PXTabItem>
-							<px:PXTabItem Text="Materials">
-								<Template>
-									<px:PXGrid SkinID="Details" SyncPosition="True" DataSourceID="ds" Width="100%" runat="server" ID="CstPXGrid17">
-										<Levels>
-											<px:PXGridLevel DataMember="LineItems" >
-												<Columns>
-													<px:PXGridColumn CommitChanges="True" DataField="InventoryID" Width="70" ></px:PXGridColumn>
-													<px:PXGridColumn DataField="InventoryID_description" Width="280" ></px:PXGridColumn>
-													<px:PXGridColumn DataField="Quantity" Width="100" ></px:PXGridColumn>
-													<px:PXGridColumn DataField="BaseUnit" Width="96" ></px:PXGridColumn></Columns></px:PXGridLevel></Levels>
-										<AutoSize MinHeight="100" Enabled="True" ></AutoSize>
-										<AutoSize MinHeight="200" ></AutoSize>
-										<Mode InitNewRow="True" ></Mode></px:PXGrid></Template></px:PXTabItem>
-							<px:PXTabItem Text="Tools">
-								<Template>
-									<px:PXGrid SkinID="Details" SyncPosition="True" DataSourceID="ds" Width="100%" runat="server" ID="CstPXGrid18">
-										<Levels>
-											<px:PXGridLevel DataMember="LineTools" >
-												<Columns>
-													<px:PXGridColumn DataField="InventoryID" Width="70" CommitChanges="True" ></px:PXGridColumn>
-													<px:PXGridColumn DataField="InventoryID_description" Width="280" ></px:PXGridColumn>
-													<px:PXGridColumn DataField="Quantity" Width="100" ></px:PXGridColumn>
-													<px:PXGridColumn DataField="BaseUnit" Width="96" ></px:PXGridColumn></Columns></px:PXGridLevel></Levels>
-										<AutoSize MinHeight="100" Enabled="True" ></AutoSize>
-										<AutoSize MinHeight="200" ></AutoSize>
-										<Mode InitNewRow="True" ></Mode></px:PXGrid></Template></px:PXTabItem>
-							<px:PXTabItem Text="Measurements">
-								<Template>
-									<px:PXGrid Width="100%" DataSourceID="ds" SkinID="Details" SyncPosition="True" runat="server" ID="CstPXGrid19">
-										<Levels>
-											<px:PXGridLevel DataMember="LineMeasurements" >
-												<Columns>
-													<px:PXGridColumn DataField="MeasurementID" Width="140" ></px:PXGridColumn>
-													<px:PXGridColumn DataField="Value" Width="100" ></px:PXGridColumn></Columns></px:PXGridLevel></Levels>
-										<Mode InitNewRow="True" ></Mode>
-										<AutoSize Enabled="True" ></AutoSize>
-										<AutoSize MinHeight="100" ></AutoSize></px:PXGrid></Template></px:PXTabItem>
-							<px:PXTabItem Text="Failure Modes" >
-								<Template>
-									<px:PXGrid Width="100%" SkinID="Details" SyncPosition="True" DataSourceID="ds" runat="server" ID="CstPXGrid20">
-										<Levels>
-											<px:PXGridLevel DataMember="LineFailureModes" >
-												<Columns>
-													<px:PXGridColumn CommitChanges="True" DataField="FailureModeID" Width="140" ></px:PXGridColumn>
-													<px:PXGridColumn DataField="Comment" Width="280" ></px:PXGridColumn></Columns></px:PXGridLevel></Levels>
-										<Mode InitNewRow="True" ></Mode>
-										<AutoSize Enabled="True" ></AutoSize>
-										<AutoSize MinHeight="100" ></AutoSize></px:PXGrid></Template></px:PXTabItem></Items>
-						<AutoSize MinHeight="100" ></AutoSize>
-						<AutoSize Enabled="True" ></AutoSize></px:PXTab></Template>
+			<px:PXTabItem Text="Details">
+						<Template>
+							<px:PXLayoutRule ControlSize="SM" LabelsWidth="S" ID="PXLayoutRule1" runat="server" StartRow="True"></px:PXLayoutRule>
+							<px:PXLayoutRule ControlSize="SM" LabelsWidth="S" runat="server" ID="CstPXLayoutRule24" StartRow="True" ></px:PXLayoutRule>
+							<px:PXLayoutRule runat="server" ID="CstPXLayoutRule25" StartColumn="True" ></px:PXLayoutRule>
+							<px:PXSelector runat="server" ID="CstPXSelector29" DataField="OrigWorkOrderID" ></px:PXSelector></Template>
 			</px:PXTabItem>
+
+			<px:PXTabItem Text="Operations">
+				<Template>
+					<px:PXSplitContainer runat="server" ID="sp1" SplitterPosition="200" SkinID="Horizontal" Height="600px" Panel1MinSize="100" Panel2MinSize="100">
+					<AutoSize Container="Window" Enabled="True" MinHeight="300" />
+					<Template1>
+						<px:PXGrid ID="grid" runat="server" DataSourceID="ds" Width="100%" Height="100%" SkinID="Details" Caption="Operations" AutoAdjustColumns="True" SyncPosition="true">
+							<Levels>
+								<px:PXGridLevel DataMember="Transactions" >
+									<Columns>
+										<px:PXGridColumn DataField="Descr" Width="400" ></px:PXGridColumn>
+										<px:PXGridColumn CommitChanges="True" DataField="EquipmentID" Width="70" ></px:PXGridColumn>
+										<px:PXGridColumn DataField="WOEquipment__Descr" Width="280" ></px:PXGridColumn></Columns>
+									<RowTemplate>
+										<px:PXSelector runat="server" ID="CstPXSelector23" DataField="EquipmentID" AllowEdit="True" ></px:PXSelector>
+									</RowTemplate>
+								</px:PXGridLevel>
+							</Levels>
+							<Mode InitNewRow="True" ></Mode>
+							<AutoCallBack Command="Refresh" Target="gridLabor" ActiveBehavior="true" >
+								<Behavior RepaintControlsIDs="gridLabor,gridMatl,gridTool,gridMeasure,gridFailure"  />
+							</AutoCallBack>
+							<AutoSize Container="Window" Enabled="True" MinHeight="150" ></AutoSize>
+						</px:PXGrid>
+
+					</Template1>
+					<Template2>
+
+						<px:PXTab DataMember="Transactions" ID="tab2" runat="server" Width="100%" DataSourceID="ds" AllowAutoHide="false">
+							<Items>
+								<px:PXTabItem Text="Labor" LoadOnDemand="True" RepaintOnDemand="True">
+									<Template>
+										<px:PXGrid SkinID="DetailsInTab" Width="100%" runat="server" ID="gridLabor">
+											<Levels>
+												<px:PXGridLevel DataMember="LineLabor" >
+													<Columns>
+														<px:PXGridColumn DataField="LaborType" Width="70" ></px:PXGridColumn>
+														<px:PXGridColumn DataField="LaborHours" Width="100" ></px:PXGridColumn></Columns></px:PXGridLevel></Levels>
+											<Mode InitNewRow="True" ></Mode>
+											<AutoSize Enabled="True" ></AutoSize>
+											<AutoSize MinHeight="100" Enabled="True" ></AutoSize>
+											<Parameters>
+												<px:PXSyncGridParam ControlID="grid" />
+											</Parameters>
+										</px:PXGrid></Template></px:PXTabItem>
+								<px:PXTabItem Text="Materials" LoadOnDemand="True" RepaintOnDemand="True">
+									<Template>
+										<px:PXGrid SkinID="DetailsInTab" SyncPosition="True" DataSourceID="ds" Width="100%" runat="server" ID="gridMatl">
+											<Levels>
+												<px:PXGridLevel DataMember="LineItems" >
+													<Columns>
+														<px:PXGridColumn CommitChanges="True" DataField="InventoryID" Width="70" ></px:PXGridColumn>
+														<px:PXGridColumn DataField="InventoryID_description" Width="280" ></px:PXGridColumn>
+														<px:PXGridColumn DataField="Quantity" Width="100" ></px:PXGridColumn>
+														<px:PXGridColumn DataField="InventoryItem__BaseUnit" Width="100" ></px:PXGridColumn></Columns></px:PXGridLevel></Levels>
+											<Mode InitNewRow="True" ></Mode>
+											<AutoSize Enabled="True" ></AutoSize>
+											<AutoSize MinHeight="100" Enabled="True" ></AutoSize>
+											<Parameters>
+												<px:PXSyncGridParam ControlID="grid" />
+											</Parameters>
+											</px:PXGrid></Template></px:PXTabItem>
+								<px:PXTabItem Text="Tools" LoadOnDemand="True" RepaintOnDemand="True">
+									<Template>
+										<px:PXGrid SkinID="DetailsInTab" SyncPosition="True" DataSourceID="ds" Width="100%" runat="server" ID="gridTool">
+											<Levels>
+												<px:PXGridLevel DataMember="LineTools" >
+													<Columns>
+														<px:PXGridColumn DataField="InventoryID" Width="70" CommitChanges="True" ></px:PXGridColumn>
+														<px:PXGridColumn DataField="InventoryID_description" Width="280" ></px:PXGridColumn>
+														<px:PXGridColumn DataField="Quantity" Width="100" ></px:PXGridColumn>
+														<px:PXGridColumn DataField="BaseUnit" Width="96" ></px:PXGridColumn></Columns></px:PXGridLevel></Levels>
+											<Mode InitNewRow="True" ></Mode>
+											<AutoSize Enabled="True" ></AutoSize>
+											<AutoSize MinHeight="100" Enabled="True" ></AutoSize>
+											<Parameters>
+												<px:PXSyncGridParam ControlID="grid" />
+											</Parameters>
+											</px:PXGrid></Template></px:PXTabItem>
+								<px:PXTabItem Text="Measurements" LoadOnDemand="True" RepaintOnDemand="True">
+									<Template>
+										<px:PXGrid Width="100%" SkinID="DetailsInTab" SyncPosition="True" DataSourceID="ds" runat="server" ID="gridMeasure">
+											<Levels>
+												<px:PXGridLevel DataMember="LineMeasurements" >
+													<Columns>
+														<px:PXGridColumn DataField="MeasurementID" Width="140" ></px:PXGridColumn>
+														<px:PXGridColumn DataField="Value" Width="100" ></px:PXGridColumn></Columns></px:PXGridLevel></Levels>
+											<Mode InitNewRow="True" ></Mode>
+											<AutoSize Enabled="True" ></AutoSize>
+											<AutoSize MinHeight="100" ></AutoSize>
+											<Parameters>
+												<px:PXSyncGridParam ControlID="grid" />
+											</Parameters>
+											</px:PXGrid></Template></px:PXTabItem>
+								<px:PXTabItem Text="Failure Modes" LoadOnDemand="True" RepaintOnDemand="True">
+									<Template>
+										<px:PXGrid Width="100%" SkinID="DetailsInTab" SyncPosition="True" DataSourceID="ds" runat="server" ID="gridFailure">
+											<Levels>
+												<px:PXGridLevel DataMember="LineFailureModes" >
+													<Columns>
+														<px:PXGridColumn CommitChanges="True" DataField="FailureModeID" Width="140" ></px:PXGridColumn>
+														<px:PXGridColumn DataField="Comment" Width="280" ></px:PXGridColumn></Columns></px:PXGridLevel></Levels>
+											<Mode InitNewRow="True" ></Mode>
+											<AutoSize Enabled="True" ></AutoSize>
+											<AutoSize MinHeight="100" ></AutoSize>
+											<Parameters>
+												<px:PXSyncGridParam ControlID="grid" />
+											</Parameters>
+											</px:PXGrid></Template></px:PXTabItem>
+							</Items>
+							<AutoSize Container="Window" Enabled="True" MinHeight="150" ></AutoSize>
+						</px:PXTab>
+
+					</Template2>
+					</px:PXSplitContainer>
+				</Template>
+			</px:PXTabItem>
+
 			<px:PXTabItem Text="Attributes">
 			  <Template>
 				<px:PXGrid runat="server" ID="PXGridAnswers" Height="200px" SkinID="Inquire" 
@@ -140,6 +181,7 @@
 							</Columns>
 						</px:PXGridLevel>
 					</Levels>
+					<AutoSize Container="Window" MinHeight="150" Enabled="True" ></AutoSize>
 				</px:PXGrid>
 			  </Template>
 			</px:PXTabItem>
@@ -172,8 +214,9 @@
 						<Mode AllowUpdate="False" ></Mode></px:PXGrid></Template>
 			</px:PXTabItem>
 		</Items>
-		<AutoSize Container="Window" Enabled="True" MinHeight="150" ></AutoSize>
+		<AutoSize Container="Window" Enabled="True" MinHeight="150" />
 	</px:PXTab>
+
 	<px:PXSmartPanel ID="panelReason" runat="server" Caption="Enter Reason" CaptionVisible="true" LoadOnDemand="true" Key="ReasonApproveRejectParams"
 	  AutoCallBack-Enabled="true" AutoCallBack-Command="Refresh" CallBackMode-CommitChanges="True" Width="600px"
 	  CallBackMode-PostData="Page" AcceptButtonID="btnReasonOk" CancelButtonID="btnReasonCancel" AllowResize="False">

--- a/CMMS_22_111_0020/Pages/WO/WO301000.aspx
+++ b/CMMS_22_111_0020/Pages/WO/WO301000.aspx
@@ -60,17 +60,19 @@
 									</RowTemplate>
 								</px:PXGridLevel>
 							</Levels>
-							<Mode InitNewRow="True" ></Mode>
+							<Mode InitNewRow="True" AllowUpload="True" />
+							<AutoSize Container="Window" Enabled="True" MinHeight="150" ></AutoSize>
+							<ActionBar ActionsText="False">
+							</ActionBar>
 							<AutoCallBack Command="Refresh" Target="gridLabor" ActiveBehavior="true" >
 								<Behavior RepaintControlsIDs="gridLabor,gridMatl,gridTool,gridMeasure,gridFailure"  />
 							</AutoCallBack>
-							<AutoSize Container="Window" Enabled="True" MinHeight="150" ></AutoSize>
 						</px:PXGrid>
 
 					</Template1>
 					<Template2>
 
-						<px:PXTab DataMember="Transactions" ID="tab2" runat="server" Width="100%" DataSourceID="ds" AllowAutoHide="false">
+						<px:PXTab ID="tab" runat="server" Width="100%" Height="100%">
 							<Items>
 								<px:PXTabItem Text="Labor" LoadOnDemand="True" RepaintOnDemand="True">
 									<Template>
@@ -80,9 +82,12 @@
 													<Columns>
 														<px:PXGridColumn DataField="LaborType" Width="70" ></px:PXGridColumn>
 														<px:PXGridColumn DataField="LaborHours" Width="100" ></px:PXGridColumn></Columns></px:PXGridLevel></Levels>
-											<Mode InitNewRow="True" ></Mode>
-											<AutoSize Enabled="True" ></AutoSize>
-											<AutoSize MinHeight="100" Enabled="True" ></AutoSize>
+											<AutoSize Enabled="True" />
+											<Mode InitNewRow="True" AllowUpload="True" />
+											<ActionBar ActionsText="False">
+											</ActionBar>
+											<AutoCallBack>
+											</AutoCallBack>
 											<Parameters>
 												<px:PXSyncGridParam ControlID="grid" />
 											</Parameters>
@@ -97,9 +102,12 @@
 														<px:PXGridColumn DataField="InventoryID_description" Width="280" ></px:PXGridColumn>
 														<px:PXGridColumn DataField="Quantity" Width="100" ></px:PXGridColumn>
 														<px:PXGridColumn DataField="InventoryItem__BaseUnit" Width="100" ></px:PXGridColumn></Columns></px:PXGridLevel></Levels>
-											<Mode InitNewRow="True" ></Mode>
-											<AutoSize Enabled="True" ></AutoSize>
-											<AutoSize MinHeight="100" Enabled="True" ></AutoSize>
+											<AutoSize Enabled="True" />
+											<Mode InitNewRow="True" AllowUpload="True" />
+											<ActionBar ActionsText="False">
+											</ActionBar>
+											<AutoCallBack>
+											</AutoCallBack>
 											<Parameters>
 												<px:PXSyncGridParam ControlID="grid" />
 											</Parameters>
@@ -114,9 +122,12 @@
 														<px:PXGridColumn DataField="InventoryID_description" Width="280" ></px:PXGridColumn>
 														<px:PXGridColumn DataField="Quantity" Width="100" ></px:PXGridColumn>
 														<px:PXGridColumn DataField="BaseUnit" Width="96" ></px:PXGridColumn></Columns></px:PXGridLevel></Levels>
-											<Mode InitNewRow="True" ></Mode>
-											<AutoSize Enabled="True" ></AutoSize>
-											<AutoSize MinHeight="100" Enabled="True" ></AutoSize>
+											<AutoSize Enabled="True" />
+											<Mode InitNewRow="True" AllowUpload="True" />
+											<ActionBar ActionsText="False">
+											</ActionBar>
+											<AutoCallBack>
+											</AutoCallBack>
 											<Parameters>
 												<px:PXSyncGridParam ControlID="grid" />
 											</Parameters>
@@ -129,9 +140,11 @@
 													<Columns>
 														<px:PXGridColumn DataField="MeasurementID" Width="140" ></px:PXGridColumn>
 														<px:PXGridColumn DataField="Value" Width="100" ></px:PXGridColumn></Columns></px:PXGridLevel></Levels>
-											<Mode InitNewRow="True" ></Mode>
-											<AutoSize Enabled="True" ></AutoSize>
-											<AutoSize MinHeight="100" ></AutoSize>
+											<AutoSize Enabled="True" />
+											<ActionBar ActionsText="False">
+											</ActionBar>
+											<AutoCallBack>
+											</AutoCallBack>
 											<Parameters>
 												<px:PXSyncGridParam ControlID="grid" />
 											</Parameters>
@@ -144,15 +157,17 @@
 													<Columns>
 														<px:PXGridColumn CommitChanges="True" DataField="FailureModeID" Width="140" ></px:PXGridColumn>
 														<px:PXGridColumn DataField="Comment" Width="280" ></px:PXGridColumn></Columns></px:PXGridLevel></Levels>
-											<Mode InitNewRow="True" ></Mode>
-											<AutoSize Enabled="True" ></AutoSize>
-											<AutoSize MinHeight="100" ></AutoSize>
+											<AutoSize Enabled="True" />
+											<ActionBar ActionsText="False">
+											</ActionBar>
+											<AutoCallBack>
+											</AutoCallBack>
 											<Parameters>
 												<px:PXSyncGridParam ControlID="grid" />
 											</Parameters>
 											</px:PXGrid></Template></px:PXTabItem>
 							</Items>
-							<AutoSize Container="Window" Enabled="True" MinHeight="150" ></AutoSize>
+							<AutoSize Enabled="True" />
 						</px:PXTab>
 
 					</Template2>

--- a/CMMS_22_111_0020/Pages/WO/WO301000.aspx
+++ b/CMMS_22_111_0020/Pages/WO/WO301000.aspx
@@ -32,14 +32,14 @@
                 <Template>
                     <px:PXFormView ID="form2" runat="server" Style="z-index: 100" Width="100%" DataMember="CurrentDocument" CaptionVisible="False" SkinID="Transparent" DataSourceID="ds" MarkRequired="Dynamic">
                         <Template>
-                    <px:PXLayoutRule ControlSize="M" LabelsWidth="SM" ID="PXLayoutRule1" runat="server" StartRow="True" />
-                    <px:PXSelector runat="server" ID="CstPXSelector29" DataField="OrigWorkOrderID"></px:PXSelector>
-                    <px:PXLayoutRule runat="server" ControlSize="M" GroupCaption="Assigned To" LabelsWidth="SM" StartGroup="True" />
-                    <px:PXSelector ID="edWorkgroupID" CommitChanges="true" runat="server" AutoRefresh="True" DataField="WorkgroupID" DataSourceID="ds" />
-                    <px:PXSelector ID="edOwnerID" CommitChanges="true" runat="server" AutoRefresh="True" DataField="OwnerID" DataSourceID="ds" />
-                      </Template>
-                        <AutoSize Container="Window" Enabled="True"/>
-                        </px:PXFormView>
+                            <px:PXLayoutRule ControlSize="M" LabelsWidth="SM" ID="PXLayoutRule1" runat="server" StartRow="True" />
+                            <px:PXSelector runat="server" ID="CstPXSelector29" DataField="OrigWorkOrderID"></px:PXSelector>
+                            <px:PXLayoutRule runat="server" ControlSize="M" GroupCaption="Assigned To" LabelsWidth="SM" StartGroup="True" />
+                            <px:PXSelector ID="edWorkgroupID" CommitChanges="true" runat="server" AutoRefresh="True" DataField="WorkgroupID" DataSourceID="ds" />
+                            <px:PXSelector ID="edOwnerID" CommitChanges="true" runat="server" AutoRefresh="True" DataField="OwnerID" DataSourceID="ds" />
+                        </Template>
+                        <AutoSize Container="Window" Enabled="True" />
+                    </px:PXFormView>
                 </Template>
             </px:PXTabItem>
 
@@ -47,8 +47,9 @@
                 <Template>
                     <px:PXGrid ID="gridOperations" runat="server" DataSourceID="ds" Style="z-index: 100" Height="200px" Width="100%" NoteIndicator="True" FilesIndicator="True"
                         SkinID="DetailsInTab" SyncPosition="True" SyncPositionWithGraph="True" MatrixMode="True">
+                        <Mode InitNewRow="True" AllowFormEdit="False" AllowUpload="True" AllowDragRows="true" />
                         <AutoSize Container="Window" Enabled="True" MinHeight="150" />
-                        <AutoCallBack Target="tab2" Command="Refresh"/>
+                        <AutoCallBack Target="tab2" Command="Refresh" />
                         <Levels>
                             <px:PXGridLevel DataMember="Transactions">
                                 <Columns>
@@ -65,8 +66,9 @@
                             <px:PXTabItem Text="Labor" LoadOnDemand="false" RepaintOnDemand="false">
                                 <Template>
                                     <px:PXGrid ID="gridLabor" runat="server" DataSourceID="ds" Style="z-index: 100" Width="100%" NoteIndicator="True" FilesIndicator="True"
-                                        SkinID="DetailsInTab" SyncPosition="True" MatrixMode="True" >
-                                        <AutoSize Container="Parent" Enabled="True" MinHeight="150"/>
+                                        SkinID="DetailsInTab" SyncPosition="True" MatrixMode="True">
+                                        <Mode InitNewRow="True" AllowFormEdit="False" AllowUpload="True" AllowDragRows="true" />
+                                        <AutoSize Container="Parent" Enabled="True" MinHeight="150" />
                                         <Levels>
                                             <px:PXGridLevel DataMember="LineLabor">
                                                 <Columns>
@@ -82,8 +84,9 @@
                             <px:PXTabItem Text="Materials" LoadOnDemand="false" RepaintOnDemand="false">
                                 <Template>
                                     <px:PXGrid ID="gridMaterials" runat="server" DataSourceID="ds" Style="z-index: 100"
-                                        Width="100%" SkinID="DetailsInTab" SyncPosition="True" MatrixMode="True"  NoteIndicator="True" FilesIndicator="True">
-                                        <AutoSize Container="Parent" Enabled="True" MinHeight="150"/>
+                                        Width="100%" SkinID="DetailsInTab" SyncPosition="True" MatrixMode="True" NoteIndicator="True" FilesIndicator="True">
+                                        <Mode InitNewRow="True" AllowFormEdit="False" AllowUpload="True" AllowDragRows="true" />
+                                        <AutoSize Container="Parent" Enabled="True" MinHeight="150" />
                                         <Levels>
                                             <px:PXGridLevel DataMember="LineItems">
                                                 <Columns>
@@ -101,8 +104,9 @@
                             <px:PXTabItem Text="Tools" LoadOnDemand="false" RepaintOnDemand="false">
                                 <Template>
                                     <px:PXGrid ID="gridTools" runat="server" DataSourceID="ds" Style="z-index: 100"
-                                        Width="100%" SkinID="DetailsInTab" SyncPosition="True" MatrixMode="True"  NoteIndicator="True" FilesIndicator="True">
-                                        <AutoSize Container="Parent" Enabled="True" MinHeight="150"/>
+                                        Width="100%" SkinID="DetailsInTab" SyncPosition="True" MatrixMode="True" NoteIndicator="True" FilesIndicator="True">
+                                        <Mode InitNewRow="True" AllowFormEdit="False" AllowUpload="True" AllowDragRows="true" />
+                                        <AutoSize Container="Parent" Enabled="True" MinHeight="150" />
                                         <Levels>
                                             <px:PXGridLevel DataMember="LineTools">
                                                 <Columns>
@@ -120,8 +124,9 @@
                             <px:PXTabItem Text="Measurements" LoadOnDemand="false" RepaintOnDemand="false">
                                 <Template>
                                     <px:PXGrid ID="gridMeasurements" runat="server" DataSourceID="ds" Style="z-index: 100"
-                                        Width="100%" SkinID="DetailsInTab" SyncPosition="True" MatrixMode="True"  NoteIndicator="True" FilesIndicator="True">
-                                        <AutoSize Container="Parent" Enabled="True" MinHeight="150"/>
+                                        Width="100%" SkinID="DetailsInTab" SyncPosition="True" MatrixMode="True" NoteIndicator="True" FilesIndicator="True">
+                                        <Mode InitNewRow="True" AllowFormEdit="False" AllowUpload="True" AllowDragRows="true" />
+                                        <AutoSize Container="Parent" Enabled="True" MinHeight="150" />
                                         <Levels>
                                             <px:PXGridLevel DataMember="LineMeasurements">
                                                 <Columns>
@@ -137,8 +142,9 @@
                             <px:PXTabItem Text="Failure Mode" LoadOnDemand="false" RepaintOnDemand="false">
                                 <Template>
                                     <px:PXGrid ID="gridFailure" runat="server" DataSourceID="ds" Style="z-index: 100"
-                                        Width="100%" SkinID="DetailsInTab" SyncPosition="True" MatrixMode="True"  NoteIndicator="True" FilesIndicator="True">
-                                        <AutoSize Container="Parent" Enabled="True" MinHeight="150"/>
+                                        Width="100%" SkinID="DetailsInTab" SyncPosition="True" MatrixMode="True" NoteIndicator="True" FilesIndicator="True">
+                                        <Mode InitNewRow="True" AllowFormEdit="False" AllowUpload="True" AllowDragRows="true" />
+                                        <AutoSize Container="Parent" Enabled="True" MinHeight="150" />
                                         <Levels>
                                             <px:PXGridLevel DataMember="LineFailureModes">
                                                 <Columns>

--- a/CMMS_22_111_0020/Pages/WO/WO301000.aspx
+++ b/CMMS_22_111_0020/Pages/WO/WO301000.aspx
@@ -30,7 +30,7 @@
         <Items>
             <px:PXTabItem Text="Details" LoadOnDemand="false" RepaintOnDemand="false">
                 <Template>
-                    <px:PXFormView ID="form2" runat="server" Style="z-index: 100" Width="100%" DataMember="Document" CaptionVisible="False" SkinID="Transparent" DataSourceID="ds" MarkRequired="Dynamic">
+<%--                    <px:PXFormView ID="form2" runat="server" Style="z-index: 100" Width="100%" DataMember="Document" CaptionVisible="False" SkinID="Transparent" DataSourceID="ds" MarkRequired="Dynamic">
                         <Template>
                     <px:PXLayoutRule ControlSize="M" LabelsWidth="SM" ID="PXLayoutRule1" runat="server" StartRow="True" />
                     <px:PXSelector runat="server" ID="CstPXSelector29" DataField="OrigWorkOrderID"></px:PXSelector>
@@ -39,7 +39,7 @@
                     <px:PXSelector ID="edOwnerID" CommitChanges="true" runat="server" AutoRefresh="True" DataField="OwnerID" DataSourceID="ds" />
                       </Template>
                         <AutoSize Container="Window" Enabled="True"/>
-                        </px:PXFormView>
+                        </px:PXFormView>--%>
                 </Template>
             </px:PXTabItem>
 

--- a/CMMS_22_111_0020/Pages/WO/WO301000.aspx
+++ b/CMMS_22_111_0020/Pages/WO/WO301000.aspx
@@ -160,6 +160,56 @@
                     </px:PXTab>
                 </Template>
             </px:PXTabItem>
-        </Items>
-    </px:PXTab>
+			<px:PXTabItem Text="Approvals">
+				<Template>
+					<px:PXGrid Caption="" SkinID="DetailsInTab" Width="100%" runat="server" ID="PXGrid1" DataSourceID="ds">
+						<Levels>
+							<px:PXGridLevel DataMember="Approval" >
+								<Columns>
+									<px:PXGridColumn DataField="ApproverEmployee__AcctName" Width="160" ></px:PXGridColumn>
+									<px:PXGridColumn DataField="ApproverEmployee__AcctCD" Width="160" ></px:PXGridColumn>
+									<px:PXGridColumn DataField="ApprovedByEmployee__AcctName" Width="100" ></px:PXGridColumn>
+									<px:PXGridColumn DataField="ApprovedByEmployee__AcctCD" Width="160" ></px:PXGridColumn>
+									<px:PXGridColumn DataField="ApproveDate" Width="90" ></px:PXGridColumn>
+									<px:PXGridColumn DataField="Status" Width="90" ></px:PXGridColumn>
+									<px:PXGridColumn DataField="Reason" Width="280" ></px:PXGridColumn>
+									<px:PXGridColumn DataField="WorkgroupID" Width="150" ></px:PXGridColumn></Columns>
+								<RowTemplate>
+									<px:PXDateTimeEdit runat="server" ID="PXDateTimeEdit1" DataField="ApproveDate" ></px:PXDateTimeEdit>
+									<px:PXTextEdit runat="server" ID="PXTextEdit1" DataField="ApprovedByEmployee__AcctCD" ></px:PXTextEdit>
+									<px:PXTextEdit runat="server" ID="PXTextEdit2" DataField="ApprovedByEmployee__AcctName" ></px:PXTextEdit>
+									<px:PXTextEdit runat="server" ID="PXTextEdit3" DataField="ApproverEmployee__AcctCD" ></px:PXTextEdit>
+									<px:PXTextEdit runat="server" ID="PXTextEdit4" DataField="ApproverEmployee__AcctName" ></px:PXTextEdit>
+									<px:PXDropDown runat="server" ID="PXDropDown1" DataField="Status" ></px:PXDropDown>
+									<px:PXSelector runat="server" ID="PXSelector1" DataField="WorkgroupID" ></px:PXSelector>
+									<px:PXTextEdit runat="server" ID="PXTextEdit5" DataField="Reason" ></px:PXTextEdit></RowTemplate>
+							</px:PXGridLevel>
+						</Levels>
+						<AutoSize Container="Window" MinHeight="150" Enabled="True" ></AutoSize>
+					
+						<Mode AllowAddNew="False" ></Mode>
+						<Mode AllowDelete="False" ></Mode>
+						<Mode AllowUpdate="False" ></Mode></px:PXGrid>
+				</Template>
+			</px:PXTabItem></Items>
+		<AutoSize Container="Window" Enabled="True" MinHeight="200" ></AutoSize>
+	</px:PXTab>
+    <px:PXSmartPanel ID="panelReason" runat="server" Caption="Enter Reason" CaptionVisible="true" LoadOnDemand="true" Key="ReasonApproveRejectParams"
+	    AutoCallBack-Enabled="true" AutoCallBack-Command="Refresh" CallBackMode-CommitChanges="True" Width="600px"
+	    CallBackMode-PostData="Page" AcceptButtonID="btnReasonOk" CancelButtonID="btnReasonCancel" AllowResize="False">
+	    <px:PXFormView ID="PXFormViewPanelReason" runat="server" DataSourceID="ds" CaptionVisible="False" DataMember="ReasonApproveRejectParams">
+		    <ContentStyle BackColor="Transparent" BorderStyle="None" Width="100%" Height="100%"  CssClass="" /> 
+		    <Template>
+			    <px:PXLayoutRule ID="PXLayoutRulePanelReason" runat="server" StartColumn="True" />
+			    <px:PXPanel ID="PXPanelReason" runat="server" RenderStyle="Simple" >
+				    <px:PXLayoutRule ID="PXLayoutRuleReason" runat="server" StartColumn="True" SuppressLabel="True" />
+				    <px:PXTextEdit ID="edReason" runat="server" DataField="Reason" TextMode="MultiLine" LabelWidth="0" Height="200px" Width="600px" CommitChanges="True" />
+			    </px:PXPanel>
+			    <px:PXPanel ID="PXPanelReasonButtons" runat="server" SkinID="Buttons">
+				    <px:PXButton ID="btnReasonOk" runat="server" Text="OK" DialogResult="Yes" CommandSourceID="ds" />
+				    <px:PXButton ID="btnReasonCancel" runat="server" Text="Cancel" DialogResult="No" CommandSourceID="ds" />
+			    </px:PXPanel>
+		    </Template>
+	    </px:PXFormView>
+    </px:PXSmartPanel>
 </asp:Content>


### PR DESCRIPTION
Added standard Attributes to Work Order Class and Work Order screen.

Enhanced Work Order screen:
   - Added attributes
   - Adjusted U/M to pull from the InventoryItem record BaseUnit field on Materials tab
   - Adjusted screen structure in accordance with Manufacturing BOM layout (Known issue to resolve at a later time -> child tabs of the Operations tab are not updating when selecting a different operation.  Compared extensively to Manufacturing BOM screen and unable to identify root cause.  Tabs update when on that tab, but not when on another tab. - Documented as Issue #23.)

Enhanced workflows for Work Order screen.
