### PR TITLE
Feature/0015 reports

### DIFF
--- a/CMMS/DAC/DBBacked/WOLineTool.cs
+++ b/CMMS/DAC/DBBacked/WOLineTool.cs
@@ -34,11 +34,18 @@ namespace CMMSlite.WO
         public abstract class lineNbr : PX.Data.BQL.BqlInt.Field<lineNbr> { }
         #endregion
 
-        #region InventoryID
-        [PX.Objects.IN.AnyInventory(Filterable = true)]
-        [PXUIField(DisplayName = Messages.FieldInventoryID)]
-        public virtual int? InventoryID { get; set; }
-        public abstract class inventoryID : PX.Data.BQL.BqlInt.Field<inventoryID> { }
+        #region EquipmentID
+        [PXDBInt()]
+        [PXSelector(
+            typeof(Search<WOEquipment.equipmentID, Where<WOEquipment.equipmentType, Equal<EquipmentTypes.tool>>>),
+            typeof(WOEquipment.equipmentCD),
+            typeof(WOEquipment.descr),
+            SubstituteKey = typeof(WOEquipment.equipmentCD),
+            DescriptionField = typeof(WOEquipment.descr)
+            )]
+        [PXUIField(DisplayName = Messages.FieldEquipmentID)]
+        public virtual int? EquipmentID { get; set; }
+        public abstract class equipmentID : PX.Data.BQL.BqlInt.Field<equipmentID> { }
         #endregion
 
         #region Quantity

--- a/CMMS/Graph/Entry/WOOrderEntry.cs
+++ b/CMMS/Graph/Entry/WOOrderEntry.cs
@@ -46,7 +46,7 @@ namespace CMMSlite.WO
         [PXViewName(Messages.ViewWOLineTools)]
         [PXImport]
         public SelectFrom<WOLineTool>
-            .InnerJoin<InventoryItem>.On<InventoryItem.inventoryID.IsEqual<WOLineTool.inventoryID>>
+            .InnerJoin<WOEquipment>.On<WOEquipment.equipmentID.IsEqual<WOLineTool.equipmentID>>
             .Where<WOLineTool.workOrderID.IsEqual<WOLine.workOrderID.FromCurrent>
                 .And<WOLineTool.wOLineNbr.IsEqual<WOLine.lineNbr.FromCurrent>>>
             .View LineTools;

--- a/CMMS_22_111_0020/Pages/WO/WO204000.aspx
+++ b/CMMS_22_111_0020/Pages/WO/WO204000.aspx
@@ -27,7 +27,6 @@
                 <Template>
                     <px:PXLayoutRule runat="server" StartRow="True" />
                     <px:PXSelector runat="server" ID="nbrBranchID" DataField="BranchID" />
-                    <px:PXSegmentMask runat="server" ID="slInventoryID" DataField="InventoryID" />
                     <px:PXTextEdit runat="server" ID="txtSerialNbr" DataField="SerialNbr" />
                     <px:PXTextEdit runat="server" ID="txtAssetID" DataField="AssetID" />
                     <px:PXSelector runat="server" ID="txtDepartmentID" DataField="DepartmentID" />
@@ -35,6 +34,7 @@
                     <px:PXDateTimeEdit runat="server" ID="dtDateInstalled" DataField="DateInstalled" />
                     <px:PXSelector runat="server" ID="slSMEquipmentID" DataField="SMEquipmentID" />
                     <px:PXSelector runat="server" ID="slAMMachID" DataField="AMMachID" />
+                    <px:PXSegmentMask runat="server" ID="slInventoryID" DataField="InventoryID" />
                 </Template>
             </px:PXTabItem>
             <px:PXTabItem Text="BOM">

--- a/CMMS_22_111_0020/Pages/WO/WO301000.aspx
+++ b/CMMS_22_111_0020/Pages/WO/WO301000.aspx
@@ -113,8 +113,8 @@
                                         <Levels>
                                             <px:PXGridLevel DataMember="LineTools">
                                                 <Columns>
-                                                    <px:PXGridColumn DataField="InventoryID" CommitChanges="True" Width="70" />
-                                                    <px:PXGridColumn DataField="InventoryID_description" Width="280" />
+                                                    <px:PXGridColumn DataField="EquipmentID" CommitChanges="True" Width="70" />
+                                                    <px:PXGridColumn DataField="Equipment_description" Width="280" />
                                                     <px:PXGridColumn DataField="Quantity" Width="100" />
                                                     <px:PXGridColumn DataField="BaseUnit" Width="96" />
                                                 </Columns>
@@ -191,7 +191,7 @@
 							</px:PXGridLevel>
 						</Levels>
                         <AutoSize Container="Window" MinHeight="150" Enabled="True"/>
-                        <Mode AllowAddNew="False" AllowDelete="False" AllowDelete="False" AllowUpdate="False" />
+                        <Mode AllowAddNew="False" AllowDelete="False" AllowUpdate="False" />
                     </px:PXGrid>
 				</Template>
 			</px:PXTabItem>

--- a/CMMS_22_111_0020/Pages/WO/WO301000.aspx
+++ b/CMMS_22_111_0020/Pages/WO/WO301000.aspx
@@ -52,16 +52,21 @@
                         SkinID="DetailsInTab" SyncPosition="True" SyncPositionWithGraph="True" MatrixMode="True">
                         <Mode InitNewRow="True" AllowFormEdit="False" AllowUpload="True" AllowDragRows="true" />
                         <AutoSize Container="Window" Enabled="True" MinHeight="150" />
-                        <AutoCallBack Target="tab2" Command="Refresh" />
-                        <Levels>
-                            <px:PXGridLevel DataMember="Transactions">
-                                <Columns>
-                                    <px:PXGridColumn DataField="EquipmentID" CommitChanges="True" Width="70" />
-                                    <px:PXGridColumn DataField="WOEquipment__Descr" Width="280" />
-                                    <px:PXGridColumn DataField="Descr" Width="400" />
-                                </Columns>
-                            </px:PXGridLevel>
-                        </Levels>
+						<AutoCallBack ActiveBehavior="True" Target="tab2" Command="Refresh" >
+							<Behavior RepaintControlsIDs="tab2,gridLabor,gridMaterials,gridTools,gridMeasurements,gridFailure" />
+						</AutoCallBack>
+						<Levels>
+							<px:PXGridLevel DataMember="Transactions">
+								<Columns>
+									<px:PXGridColumn DataField="Descr" Width="400"/>
+									<px:PXGridColumn CommitChanges="True" DataField="EquipmentID" Width="70"/>
+									<px:PXGridColumn DataField="WOEquipment__Descr" Width="280"/>
+								</Columns>
+								<RowTemplate>
+									<px:PXSelector runat="server" ID="CstPXSelector23" DataField="EquipmentID" AllowEdit="True"/>
+								</RowTemplate>
+							</px:PXGridLevel>
+						</Levels>
                     </px:PXGrid>
 
                     <px:PXTab ID="tab2" runat="server" Style="z-index: 100;" Width="100%" DataMember="CurrentDocument" SyncPosition="True">
@@ -162,6 +167,30 @@
                         </Items>
                     </px:PXTab>
                 </Template>
+            </px:PXTabItem>
+            <px:PXTabItem Text="Attributes">
+              <Template>
+                <px:PXGrid runat="server" ID="PXGridAnswers" Height="200px" SkinID="Inquire" 
+                            Width="100%" MatrixMode="True" DataSourceID="ds">
+                    <AutoSize Enabled="True" MinHeight="200" ></AutoSize>
+                    <ActionBar>
+                        <Actions>
+                            <Search Enabled="False" ></Search>
+                        </Actions>
+                    </ActionBar>
+                    <Mode AllowAddNew="False" AllowDelete="False" AllowColMoving="False" ></Mode>
+                    <Levels>
+                        <px:PXGridLevel DataMember="Answers">                        
+                            <Columns>
+                                <px:PXGridColumn TextAlign="Left" DataField="AttributeID" TextField="AttributeID_description" 
+                                                    Width="250px" AllowShowHide="False" ></px:PXGridColumn>
+                                <px:PXGridColumn Type="CheckBox" TextAlign="Center" DataField="isRequired" Width="80px" ></px:PXGridColumn>
+                                <px:PXGridColumn DataField="Value" Width="300px" AllowSort="False" AllowShowHide="False" ></px:PXGridColumn>
+                            </Columns>
+                        </px:PXGridLevel>
+                    </Levels>
+                </px:PXGrid>
+              </Template>
             </px:PXTabItem>
 			<px:PXTabItem Text="Approvals">
 				<Template>

--- a/Package/CMMS/_project/REPORT_WO601000_RPX.xml
+++ b/Package/CMMS/_project/REPORT_WO601000_RPX.xml
@@ -1,0 +1,548 @@
+﻿<Report Name="wo601000.rpx">
+    <Report version="20211215" Name="report1">
+        <LayoutUnit>Inch</LayoutUnit>
+        <PageSettings>
+            <Margins>
+            </Margins>
+            <PaperKind>Letter</PaperKind>
+        </PageSettings>
+        <SchemaUrl>http://localhost/CMMS</SchemaUrl>
+        <Tables>
+            <ReportTable Name="WOEquipment">
+                <Fields>
+                    <ReportField Name="AMMachID">
+                    </ReportField>
+                    <ReportField Name="AMMachID_AMMach_descr">
+                    </ReportField>
+                    <ReportField Name="AMMachID_description">
+                    </ReportField>
+                    <ReportField Name="AssetID">
+                    </ReportField>
+                    <ReportField Name="BranchID">
+                        <DataType>Int32</DataType>
+                    </ReportField>
+                    <ReportField Name="CreatedByID">
+                    </ReportField>
+                    <ReportField Name="CreatedByID_Creator_displayName">
+                    </ReportField>
+                    <ReportField Name="CreatedByID_Creator_Username">
+                    </ReportField>
+                    <ReportField Name="CreatedByID_description">
+                    </ReportField>
+                    <ReportField Name="CreatedByScreenID">
+                    </ReportField>
+                    <ReportField Name="CreatedDateTime">
+                        <DataType>DateTime</DataType>
+                    </ReportField>
+                    <ReportField Name="CreatedDateTime_Day">
+                    </ReportField>
+                    <ReportField Name="CreatedDateTime_Hour">
+                    </ReportField>
+                    <ReportField Name="CreatedDateTime_Month">
+                    </ReportField>
+                    <ReportField Name="CreatedDateTime_Quarter">
+                    </ReportField>
+                    <ReportField Name="Criticality">
+                    </ReportField>
+                    <ReportField Name="DateInstalled">
+                        <DataType>DateTime</DataType>
+                    </ReportField>
+                    <ReportField Name="DateInstalled_Day">
+                    </ReportField>
+                    <ReportField Name="DateInstalled_Hour">
+                    </ReportField>
+                    <ReportField Name="DateInstalled_Month">
+                    </ReportField>
+                    <ReportField Name="DateInstalled_Quarter">
+                    </ReportField>
+                    <ReportField Name="DepartmentID">
+                    </ReportField>
+                    <ReportField Name="Descr">
+                    </ReportField>
+                    <ReportField Name="EquipmentCD">
+                    </ReportField>
+                    <ReportField Name="EquipmentID">
+                        <DataType>Int32</DataType>
+                    </ReportField>
+                    <ReportField Name="EquipmentType">
+                    </ReportField>
+                    <ReportField Name="InventoryID">
+                    </ReportField>
+                    <ReportField Name="InventoryID_description">
+                    </ReportField>
+                    <ReportField Name="InventoryID_InventoryItem_descr">
+                    </ReportField>
+                    <ReportField Name="InventoryID_Segment1">
+                    </ReportField>
+                    <ReportField Name="LastModifiedByID">
+                    </ReportField>
+                    <ReportField Name="LastModifiedByID_description">
+                    </ReportField>
+                    <ReportField Name="LastModifiedByID_Modifier_displayName">
+                    </ReportField>
+                    <ReportField Name="LastModifiedByID_Modifier_Username">
+                    </ReportField>
+                    <ReportField Name="LastModifiedByScreenID">
+                    </ReportField>
+                    <ReportField Name="LastModifiedDateTime">
+                        <DataType>DateTime</DataType>
+                    </ReportField>
+                    <ReportField Name="LastModifiedDateTime_Day">
+                    </ReportField>
+                    <ReportField Name="LastModifiedDateTime_Hour">
+                    </ReportField>
+                    <ReportField Name="LastModifiedDateTime_Month">
+                    </ReportField>
+                    <ReportField Name="LastModifiedDateTime_Quarter">
+                    </ReportField>
+                    <ReportField Name="NoteActivity">
+                    </ReportField>
+                    <ReportField Name="NoteFiles">
+                    </ReportField>
+                    <ReportField Name="NoteID">
+                        <DataType>Object</DataType>
+                    </ReportField>
+                    <ReportField Name="NoteImages">
+                    </ReportField>
+                    <ReportField Name="NoteText">
+                    </ReportField>
+                    <ReportField Name="PhysicalLocation">
+                    </ReportField>
+                    <ReportField Name="SerialNbr">
+                    </ReportField>
+                    <ReportField Name="SMEquipmentID">
+                    </ReportField>
+                    <ReportField Name="SMEquipmentID_description">
+                    </ReportField>
+                    <ReportField Name="SMEquipmentID_FSEquipment_descr">
+                    </ReportField>
+                    <ReportField Name="Status">
+                    </ReportField>
+                    <ReportField Name="Tstamp">
+                    </ReportField>
+                </Fields>
+                <FullName>CMMSlite.WO.WOEquipment</FullName>
+            </ReportTable>
+        </Tables>
+        <Version>20211215</Version>
+        <Sections>
+            <PageHeader Name="pageHeaderSection1">
+                <Height>0.58333in</Height>
+                <Items>
+                    <TextBox Name="textBox33">
+                        <Location>48px, 24px</Location>
+                        <Size>176px, 24px</Size>
+                        <Value>=Report.GetDefUI('AccessInfo.DisplayName')</Value>
+                        <WrapText>False</WrapText>
+                    </TextBox>
+                    <TextBox Name="textBox35">
+                        <Location>0px, 24px</Location>
+                        <Size>40px, 24px</Size>
+                        <Style>
+                            <Font>
+                                <Style>Bold</Style>
+                            </Font>
+                        </Style>
+                        <Value>User:</Value>
+                    </TextBox>
+                    <TextBox Name="textBox37">
+                        <Location>640px, 24px</Location>
+                        <Size>80px, 24px</Size>
+                        <Style>
+                            <TextAlign>Right</TextAlign>
+                        </Style>
+                        <Value>=[@Today]</Value>
+                    </TextBox>
+                    <TextBox Name="textBox38">
+                        <Location>568px, 24px</Location>
+                        <Size>64px, 24px</Size>
+                        <Style>
+                            <Font>
+                                <Style>Bold</Style>
+                            </Font>
+                        </Style>
+                        <Value>Date:</Value>
+                    </TextBox>
+                    <TextBox Name="textBox39">
+                        <Location>568px, 0px</Location>
+                        <Size>64px, 24px</Size>
+                        <Style>
+                            <Font>
+                                <Style>Bold</Style>
+                            </Font>
+                        </Style>
+                        <Value>Page:</Value>
+                    </TextBox>
+                    <TextBox Name="textBox40">
+                        <Location>640px, 0px</Location>
+                        <Size>80px, 24px</Size>
+                        <Style>
+                            <TextAlign>Right</TextAlign>
+                        </Style>
+                        <Value>=[PageOf]</Value>
+                    </TextBox>
+                    <TextBox Name="textBox41">
+                        <Location>0px, 0px</Location>
+                        <Size>184px, 16px</Size>
+                        <Style>
+                            <Font>
+                                <Style>Bold</Style>
+                            </Font>
+                        </Style>
+                        <Value>CMMS EQUIPMENT</Value>
+                    </TextBox>
+                </Items>
+            </PageHeader>
+            <Detail Name="detailSection1">
+                <Height>3.58333in</Height>
+                <Items>
+                    <Panel Name="panel1">
+                        <Location>0px, 8px</Location>
+                        <Size>720px, 24px</Size>
+                        <Style>
+                            <BackColor>AliceBlue</BackColor>
+                            <BorderStyle>
+                                <Bottom>Solid</Bottom>
+                                <Top>Solid</Top>
+                            </BorderStyle>
+                        </Style>
+                        <Items>
+                            <TextBox Name="textBox10">
+                                <Location>144px, 0px</Location>
+                                <Size>304px, 24px</Size>
+                                <Style>
+                                    <Font>
+                                        <Style>Bold</Style>
+                                    </Font>
+                                </Style>
+                                <Value>Description</Value>
+                            </TextBox>
+                            <TextBox Name="textBox11">
+                                <Location>456px, 0px</Location>
+                                <Size>120px, 24px</Size>
+                                <Style>
+                                    <Font>
+                                        <Style>Bold</Style>
+                                    </Font>
+                                </Style>
+                                <Value>Status</Value>
+                            </TextBox>
+                            <TextBox Name="textBox12">
+                                <Location>600px, 0px</Location>
+                                <Size>88px, 24px</Size>
+                                <Style>
+                                    <Font>
+                                        <Style>Bold</Style>
+                                    </Font>
+                                </Style>
+                                <Value>Criticality</Value>
+                            </TextBox>
+                            <TextBox Name="textBox9">
+                                <Location>16px, 0px</Location>
+                                <Size>120px, 24px</Size>
+                                <Style>
+                                    <Font>
+                                        <Style>Bold</Style>
+                                    </Font>
+                                </Style>
+                                <Value>Equipment ID</Value>
+                            </TextBox>
+                        </Items>
+                    </Panel>
+                    <SubReport Name="subReport1">
+                        <Location>32px, 136px</Location>
+                        <Parameters>
+                            <ExternalParameter>
+                                <Name>EquipmentID</Name>
+                                <ValueExpr>=[WOEquipment.EquipmentID]</ValueExpr>
+                            </ExternalParameter>
+                        </Parameters>
+                        <ReportName>wo601001.rpx</ReportName>
+                        <Size>656px, 24px</Size>
+                    </SubReport>
+                    <SubReport Name="subReport2">
+                        <Location>32px, 224px</Location>
+                        <Parameters>
+                            <ExternalParameter>
+                                <Name>EquipmentID</Name>
+                                <ValueExpr>=[WOEquipment.EquipmentID]</ValueExpr>
+                            </ExternalParameter>
+                        </Parameters>
+                        <ReportName>wo601002.rpx</ReportName>
+                        <Size>656px, 24px</Size>
+                    </SubReport>
+                    <SubReport Name="subReport3">
+                        <Location>32px, 312px</Location>
+                        <Parameters>
+                            <ExternalParameter>
+                                <Name>EquipmentID</Name>
+                                <ValueExpr>=[WOEquipment.EquipmentID]</ValueExpr>
+                            </ExternalParameter>
+                        </Parameters>
+                        <ReportName>wo601003.rpx</ReportName>
+                        <Size>656px, 24px</Size>
+                    </SubReport>
+                    <TextBox Name="textBox1">
+                        <Location>16px, 32px</Location>
+                        <Size>120px, 24px</Size>
+                        <Value>=[WOEquipment.EquipmentCD]</Value>
+                    </TextBox>
+                    <TextBox Name="textBox13">
+                        <Location>304px, 56px</Location>
+                        <Size>40px, 24px</Size>
+                        <Style>
+                            <Font>
+                                <Style>Bold</Style>
+                            </Font>
+                            <TextAlign>Right</TextAlign>
+                        </Style>
+                        <Value>Type:</Value>
+                    </TextBox>
+                    <TextBox Name="textBox14">
+                        <Location>432px, 56px</Location>
+                        <Size>40px, 24px</Size>
+                        <Style>
+                            <Font>
+                                <Style>Bold</Style>
+                            </Font>
+                            <TextAlign>Right</TextAlign>
+                        </Style>
+                        <Value>Dept:</Value>
+                    </TextBox>
+                    <TextBox Name="textBox15">
+                        <Location>64px, 56px</Location>
+                        <Size>40px, 24px</Size>
+                        <Style>
+                            <Font>
+                                <Style>Bold</Style>
+                            </Font>
+                            <TextAlign>Right</TextAlign>
+                        </Style>
+                        <Value>S/N:</Value>
+                    </TextBox>
+                    <TextBox Name="textBox16">
+                        <Location>552px, 56px</Location>
+                        <Size>40px, 24px</Size>
+                        <Style>
+                            <Font>
+                                <Style>Bold</Style>
+                            </Font>
+                            <TextAlign>Right</TextAlign>
+                        </Style>
+                        <Value>Loc:</Value>
+                    </TextBox>
+                    <TextBox Name="textBox2">
+                        <Location>352px, 56px</Location>
+                        <Size>72px, 24px</Size>
+                        <Value>=[WOEquipment.EquipmentType]</Value>
+                    </TextBox>
+                    <TextBox Name="textBox20">
+                        <Location>32px, 88px</Location>
+                        <Size>632px, 24px</Size>
+                        <Style>
+                            <Font>
+                                <Style>Bold, Underline</Style>
+                            </Font>
+                        </Style>
+                        <Value>Bill of Material</Value>
+                    </TextBox>
+                    <TextBox Name="textBox21">
+                        <Location>32px, 176px</Location>
+                        <Size>632px, 24px</Size>
+                        <Style>
+                            <Font>
+                                <Style>Bold, Underline</Style>
+                            </Font>
+                        </Style>
+                        <Value>Failure Modes</Value>
+                    </TextBox>
+                    <TextBox Name="textBox22">
+                        <Location>440px, 288px</Location>
+                        <Size>72px, 24px</Size>
+                        <Style>
+                            <Font>
+                                <Size>10pt</Size>
+                                <Style>Bold</Style>
+                            </Font>
+                        </Style>
+                        <Value>Frequency</Value>
+                    </TextBox>
+                    <TextBox Name="textBox23">
+                        <Location>32px, 264px</Location>
+                        <Size>624px, 24px</Size>
+                        <Style>
+                            <Font>
+                                <Style>Bold, Underline</Style>
+                            </Font>
+                        </Style>
+                        <Value>Schedules</Value>
+                    </TextBox>
+                    <TextBox Name="textBox24">
+                        <Location>360px, 288px</Location>
+                        <Size>80px, 24px</Size>
+                        <Style>
+                            <Font>
+                                <Size>10pt</Size>
+                                <Style>Bold</Style>
+                            </Font>
+                        </Style>
+                        <Value>Lead Time</Value>
+                    </TextBox>
+                    <TextBox Name="textBox25">
+                        <Location>584px, 288px</Location>
+                        <Size>72px, 24px</Size>
+                        <Style>
+                            <Font>
+                                <Size>10pt</Size>
+                                <Style>Bold</Style>
+                            </Font>
+                        </Style>
+                        <Value>Next Date</Value>
+                    </TextBox>
+                    <TextBox Name="textBox26">
+                        <Location>512px, 288px</Location>
+                        <Size>72px, 24px</Size>
+                        <Style>
+                            <Font>
+                                <Size>10pt</Size>
+                                <Style>Bold</Style>
+                            </Font>
+                        </Style>
+                        <Value>Last Date</Value>
+                    </TextBox>
+                    <TextBox Name="textBox27">
+                        <Location>32px, 288px</Location>
+                        <Size>120px, 24px</Size>
+                        <Style>
+                            <Font>
+                                <Size>10pt</Size>
+                                <Style>Bold</Style>
+                            </Font>
+                        </Style>
+                        <Value>Work Order ID</Value>
+                    </TextBox>
+                    <TextBox Name="textBox28">
+                        <Location>160px, 288px</Location>
+                        <Size>192px, 24px</Size>
+                        <Style>
+                            <Font>
+                                <Size>10pt</Size>
+                                <Style>Bold</Style>
+                            </Font>
+                        </Style>
+                        <Value>Description</Value>
+                    </TextBox>
+                    <TextBox Name="textBox29">
+                        <Location>32px, 200px</Location>
+                        <Size>104px, 24px</Size>
+                        <Style>
+                            <Font>
+                                <Size>10pt</Size>
+                                <Style>Bold</Style>
+                            </Font>
+                        </Style>
+                        <Value>Failure Mode</Value>
+                    </TextBox>
+                    <TextBox Name="textBox3">
+                        <Location>144px, 32px</Location>
+                        <Size>304px, 24px</Size>
+                        <Value>=[WOEquipment.Descr]</Value>
+                    </TextBox>
+                    <TextBox Name="textBox30">
+                        <Location>160px, 200px</Location>
+                        <Size>208px, 24px</Size>
+                        <Style>
+                            <Font>
+                                <Size>10pt</Size>
+                                <Style>Bold</Style>
+                            </Font>
+                        </Style>
+                        <Value>Description</Value>
+                    </TextBox>
+                    <TextBox Name="textBox31">
+                        <Location>160px, 112px</Location>
+                        <Size>208px, 24px</Size>
+                        <Style>
+                            <Font>
+                                <Size>10pt</Size>
+                                <Style>Bold</Style>
+                            </Font>
+                        </Style>
+                        <Value>Description</Value>
+                    </TextBox>
+                    <TextBox Name="textBox32">
+                        <Location>32px, 112px</Location>
+                        <Size>104px, 24px</Size>
+                        <Style>
+                            <Font>
+                                <Size>10pt</Size>
+                                <Style>Bold</Style>
+                            </Font>
+                        </Style>
+                        <Value>Inventory ID</Value>
+                    </TextBox>
+                    <TextBox Name="textBox34">
+                        <Location>432px, 112px</Location>
+                        <Size>64px, 24px</Size>
+                        <Style>
+                            <Font>
+                                <Size>10pt</Size>
+                                <Style>Bold</Style>
+                            </Font>
+                        </Style>
+                        <Value>Quantity</Value>
+                    </TextBox>
+                    <TextBox Name="textBox36">
+                        <Location>600px, 112px</Location>
+                        <Size>64px, 24px</Size>
+                        <Style>
+                            <Font>
+                                <Size>10pt</Size>
+                                <Style>Bold</Style>
+                            </Font>
+                        </Style>
+                        <Value>Criticality</Value>
+                    </TextBox>
+                    <TextBox Name="textBox4">
+                        <Location>480px, 56px</Location>
+                        <Size>64px, 24px</Size>
+                        <Value>=[WOEquipment.DepartmentID]</Value>
+                    </TextBox>
+                    <TextBox Name="textBox5">
+                        <Location>112px, 56px</Location>
+                        <Size>184px, 24px</Size>
+                        <Value>=[WOEquipment.SerialNbr]</Value>
+                    </TextBox>
+                    <TextBox Name="textBox6">
+                        <Location>456px, 32px</Location>
+                        <Size>120px, 24px</Size>
+                        <Value>=[WOEquipment.Status]</Value>
+                    </TextBox>
+                    <TextBox Name="textBox7">
+                        <Location>600px, 32px</Location>
+                        <Size>88px, 24px</Size>
+                        <Value>=[WOEquipment.Criticality]</Value>
+                    </TextBox>
+                    <TextBox Name="textBox8">
+                        <Location>600px, 56px</Location>
+                        <Size>88px, 24px</Size>
+                        <Value>=[WOEquipment.PhysicalLocation]</Value>
+                    </TextBox>
+                </Items>
+            </Detail>
+            <PageFooter Name="pageFooterSection1">
+                <Height>0.25in</Height>
+                <Items>
+                    <TextBox Name="textBox19">
+                        <Location>288px, 0px</Location>
+                        <Size>120px, 16px</Size>
+                        <Style>
+                            <TextAlign>Center</TextAlign>
+                        </Style>
+                        <Value>=[@Today]</Value>
+                    </TextBox>
+                </Items>
+            </PageFooter>
+        </Sections>
+    </Report>
+</Report>

--- a/Package/CMMS/_project/REPORT_WO601001_RPX.xml
+++ b/Package/CMMS/_project/REPORT_WO601001_RPX.xml
@@ -1,0 +1,1020 @@
+﻿<Report Name="wo601001.rpx">
+    <Report version="20211215" Name="report1">
+        <Filters>
+            <FilterExp>
+                <DataField>WOEquipmentBOM.EquipmentID</DataField>
+                <Value>@EquipmentID</Value>
+            </FilterExp>
+        </Filters>
+        <Parameters>
+            <ReportParameter>
+                <DefaultValue>1</DefaultValue>
+                <Name>EquipmentID</Name>
+                <ViewName>=[WOEquipmentBOM.EquipmentID]</ViewName>
+            </ReportParameter>
+        </Parameters>
+        <Relations>
+            <ReportRelation>
+                <ChildName>InventoryItem</ChildName>
+                <Links>
+                    <RelationRow>
+                        <ChildField>InventoryID</ChildField>
+                        <ParentField>InventoryID</ParentField>
+                    </RelationRow>
+                </Links>
+                <ParentName>WOEquipmentBOM</ParentName>
+            </ReportRelation>
+        </Relations>
+        <SchemaUrl>http://localhost/CMMS</SchemaUrl>
+        <Tables>
+            <ReportTable Name="WOEquipmentBOM">
+                <Fields>
+                    <ReportField Name="CreatedByID">
+                    </ReportField>
+                    <ReportField Name="CreatedByID_Creator_displayName">
+                    </ReportField>
+                    <ReportField Name="CreatedByID_Creator_Username">
+                    </ReportField>
+                    <ReportField Name="CreatedByID_description">
+                    </ReportField>
+                    <ReportField Name="CreatedByScreenID">
+                    </ReportField>
+                    <ReportField Name="CreatedDateTime">
+                        <DataType>DateTime</DataType>
+                    </ReportField>
+                    <ReportField Name="CreatedDateTime_Day">
+                    </ReportField>
+                    <ReportField Name="CreatedDateTime_Hour">
+                    </ReportField>
+                    <ReportField Name="CreatedDateTime_Month">
+                    </ReportField>
+                    <ReportField Name="CreatedDateTime_Quarter">
+                    </ReportField>
+                    <ReportField Name="Criticality">
+                    </ReportField>
+                    <ReportField Name="EquipmentID">
+                        <DataType>Int32</DataType>
+                    </ReportField>
+                    <ReportField Name="InventoryID">
+                    </ReportField>
+                    <ReportField Name="LastModifiedByID">
+                    </ReportField>
+                    <ReportField Name="LastModifiedByID_description">
+                    </ReportField>
+                    <ReportField Name="LastModifiedByID_Modifier_displayName">
+                    </ReportField>
+                    <ReportField Name="LastModifiedByID_Modifier_Username">
+                    </ReportField>
+                    <ReportField Name="LastModifiedByScreenID">
+                    </ReportField>
+                    <ReportField Name="LastModifiedDateTime">
+                        <DataType>DateTime</DataType>
+                    </ReportField>
+                    <ReportField Name="LastModifiedDateTime_Day">
+                    </ReportField>
+                    <ReportField Name="LastModifiedDateTime_Hour">
+                    </ReportField>
+                    <ReportField Name="LastModifiedDateTime_Month">
+                    </ReportField>
+                    <ReportField Name="LastModifiedDateTime_Quarter">
+                    </ReportField>
+                    <ReportField Name="NoteActivity">
+                    </ReportField>
+                    <ReportField Name="NoteFiles">
+                    </ReportField>
+                    <ReportField Name="NoteID">
+                        <DataType>Object</DataType>
+                    </ReportField>
+                    <ReportField Name="NoteImages">
+                    </ReportField>
+                    <ReportField Name="NoteText">
+                    </ReportField>
+                    <ReportField Name="Quantity">
+                        <DataType>Decimal</DataType>
+                    </ReportField>
+                    <ReportField Name="Tstamp">
+                    </ReportField>
+                </Fields>
+                <FullName>CMMSlite.WO.WOEquipmentBOM</FullName>
+            </ReportTable>
+            <ReportTable Name="InventoryItem">
+                <Fields>
+                    <ReportField Name="ABCCodeID">
+                    </ReportField>
+                    <ReportField Name="ABCCodeID_description">
+                    </ReportField>
+                    <ReportField Name="ABCCodeID_INABCCode_descr">
+                    </ReportField>
+                    <ReportField Name="ABCCodeIsFixed">
+                        <DataType>Boolean</DataType>
+                    </ReportField>
+                    <ReportField Name="AccrueCost">
+                        <DataType>Boolean</DataType>
+                    </ReportField>
+                    <ReportField Name="AMBOMID">
+                    </ReportField>
+                    <ReportField Name="AMBOMID_AMBomItem_descr">
+                    </ReportField>
+                    <ReportField Name="AMBOMID_description">
+                    </ReportField>
+                    <ReportField Name="AMCheckSchdMatlAvailability">
+                        <DataType>Boolean</DataType>
+                    </ReportField>
+                    <ReportField Name="AMConfigurationID">
+                    </ReportField>
+                    <ReportField Name="AMConfigurationID_AMConfiguration_descr">
+                    </ReportField>
+                    <ReportField Name="AMConfigurationID_description">
+                    </ReportField>
+                    <ReportField Name="AMCTPItem">
+                        <DataType>Boolean</DataType>
+                    </ReportField>
+                    <ReportField Name="AMDefaultMarkFor">
+                        <DataType>Int32</DataType>
+                    </ReportField>
+                    <ReportField Name="AMGroupWindow">
+                        <DataType>Int32</DataType>
+                    </ReportField>
+                    <ReportField Name="AMGroupWindowOverride">
+                        <DataType>Boolean</DataType>
+                    </ReportField>
+                    <ReportField Name="AMLotSize">
+                        <DataType>Decimal</DataType>
+                    </ReportField>
+                    <ReportField Name="AMLowLevel">
+                        <DataType>Int32</DataType>
+                    </ReportField>
+                    <ReportField Name="AMMakeToOrderItem">
+                        <DataType>Boolean</DataType>
+                    </ReportField>
+                    <ReportField Name="AMMaxOrdQty">
+                        <DataType>Decimal</DataType>
+                    </ReportField>
+                    <ReportField Name="AMMFGLeadTime">
+                        <DataType>Int32</DataType>
+                    </ReportField>
+                    <ReportField Name="AMMinOrdQty">
+                        <DataType>Decimal</DataType>
+                    </ReportField>
+                    <ReportField Name="AMMinQty">
+                        <DataType>Decimal</DataType>
+                    </ReportField>
+                    <ReportField Name="AMMinQtyOverride">
+                        <DataType>Boolean</DataType>
+                    </ReportField>
+                    <ReportField Name="AMMRPItem">
+                        <DataType>Boolean</DataType>
+                    </ReportField>
+                    <ReportField Name="AMPlanningBOMID">
+                    </ReportField>
+                    <ReportField Name="AMPlanningBOMID_AMBomItem_descr">
+                    </ReportField>
+                    <ReportField Name="AMPlanningBOMID_description">
+                    </ReportField>
+                    <ReportField Name="AMQtyRoundUp">
+                        <DataType>Boolean</DataType>
+                    </ReportField>
+                    <ReportField Name="AMReplenishmentSource">
+                    </ReportField>
+                    <ReportField Name="AMReplenishmentSourceOverride">
+                        <DataType>Boolean</DataType>
+                    </ReportField>
+                    <ReportField Name="AMSafetyStock">
+                        <DataType>Decimal</DataType>
+                    </ReportField>
+                    <ReportField Name="AMSafetyStockOverride">
+                        <DataType>Boolean</DataType>
+                    </ReportField>
+                    <ReportField Name="AMScrapLocationID">
+                    </ReportField>
+                    <ReportField Name="AMScrapLocationID_description">
+                    </ReportField>
+                    <ReportField Name="AMScrapLocationID_INLocation_descr">
+                    </ReportField>
+                    <ReportField Name="AMScrapLocationID_Segment1">
+                    </ReportField>
+                    <ReportField Name="AMScrapSiteID">
+                    </ReportField>
+                    <ReportField Name="AMScrapSiteID_description">
+                    </ReportField>
+                    <ReportField Name="AMScrapSiteID_INSite_descr">
+                    </ReportField>
+                    <ReportField Name="AMScrapSiteID_Segment1">
+                    </ReportField>
+                    <ReportField Name="AMWIPAcctID">
+                    </ReportField>
+                    <ReportField Name="AMWIPAcctID_Account_description">
+                    </ReportField>
+                    <ReportField Name="AMWIPAcctID_description">
+                    </ReportField>
+                    <ReportField Name="AMWIPAcctID_Segment1">
+                    </ReportField>
+                    <ReportField Name="AMWIPSubID">
+                    </ReportField>
+                    <ReportField Name="AMWIPSubID_description">
+                    </ReportField>
+                    <ReportField Name="AMWIPSubID_Segment1">
+                    </ReportField>
+                    <ReportField Name="AMWIPSubID_Segment2">
+                    </ReportField>
+                    <ReportField Name="AMWIPSubID_Sub_description">
+                    </ReportField>
+                    <ReportField Name="AMWIPVarianceAcctID">
+                    </ReportField>
+                    <ReportField Name="AMWIPVarianceAcctID_Account_description">
+                    </ReportField>
+                    <ReportField Name="AMWIPVarianceAcctID_description">
+                    </ReportField>
+                    <ReportField Name="AMWIPVarianceAcctID_Segment1">
+                    </ReportField>
+                    <ReportField Name="AMWIPVarianceSubID">
+                    </ReportField>
+                    <ReportField Name="AMWIPVarianceSubID_description">
+                    </ReportField>
+                    <ReportField Name="AMWIPVarianceSubID_Segment1">
+                    </ReportField>
+                    <ReportField Name="AMWIPVarianceSubID_Segment2">
+                    </ReportField>
+                    <ReportField Name="AMWIPVarianceSubID_Sub_description">
+                    </ReportField>
+                    <ReportField Name="AttributeDescriptionGroupID">
+                        <DataType>Int32</DataType>
+                    </ReportField>
+                    <ReportField Name="Availability">
+                    </ReportField>
+                    <ReportField Name="BaseItemVolume">
+                        <DataType>Decimal</DataType>
+                    </ReportField>
+                    <ReportField Name="BaseItemWeight">
+                        <DataType>Decimal</DataType>
+                    </ReportField>
+                    <ReportField Name="BasePrice">
+                        <DataType>Decimal</DataType>
+                    </ReportField>
+                    <ReportField Name="BaseUnit">
+                    </ReportField>
+                    <ReportField Name="BaseVolume">
+                        <DataType>Decimal</DataType>
+                    </ReportField>
+                    <ReportField Name="BaseWeight">
+                        <DataType>Decimal</DataType>
+                    </ReportField>
+                    <ReportField Name="BenefitExpenseAcctID">
+                    </ReportField>
+                    <ReportField Name="BenefitExpenseAcctID_Account_description">
+                    </ReportField>
+                    <ReportField Name="BenefitExpenseAcctID_description">
+                    </ReportField>
+                    <ReportField Name="BenefitExpenseAcctID_Segment1">
+                    </ReportField>
+                    <ReportField Name="BenefitExpenseSubID">
+                    </ReportField>
+                    <ReportField Name="BenefitExpenseSubID_description">
+                    </ReportField>
+                    <ReportField Name="BenefitExpenseSubID_Segment1">
+                    </ReportField>
+                    <ReportField Name="BenefitExpenseSubID_Segment2">
+                    </ReportField>
+                    <ReportField Name="BenefitExpenseSubID_Sub_description">
+                    </ReportField>
+                    <ReportField Name="Body">
+                    </ReportField>
+                    <ReportField Name="ClassID">
+                        <DataType>Int32</DataType>
+                    </ReportField>
+                    <ReportField Name="COGSAcctID">
+                    </ReportField>
+                    <ReportField Name="COGSAcctID_Account_description">
+                    </ReportField>
+                    <ReportField Name="COGSAcctID_description">
+                    </ReportField>
+                    <ReportField Name="COGSAcctID_Segment1">
+                    </ReportField>
+                    <ReportField Name="COGSSubID">
+                    </ReportField>
+                    <ReportField Name="COGSSubID_description">
+                    </ReportField>
+                    <ReportField Name="COGSSubID_Segment1">
+                    </ReportField>
+                    <ReportField Name="COGSSubID_Segment2">
+                    </ReportField>
+                    <ReportField Name="COGSSubID_Sub_description">
+                    </ReportField>
+                    <ReportField Name="COLOR_Attributes">
+                    </ReportField>
+                    <ReportField Name="ColumnAttributeValue">
+                    </ReportField>
+                    <ReportField Name="Commisionable">
+                        <DataType>Boolean</DataType>
+                    </ReportField>
+                    <ReportField Name="CompletePOLine">
+                    </ReportField>
+                    <ReportField Name="CONFIGURAB_Attributes">
+                    </ReportField>
+                    <ReportField Name="CostBasis">
+                    </ReportField>
+                    <ReportField Name="CountryOfOrigin">
+                    </ReportField>
+                    <ReportField Name="CountryOfOrigin_Country_description">
+                    </ReportField>
+                    <ReportField Name="CountryOfOrigin_description">
+                    </ReportField>
+                    <ReportField Name="CreatedByID">
+                    </ReportField>
+                    <ReportField Name="CreatedByID_Creator_displayName">
+                    </ReportField>
+                    <ReportField Name="CreatedByID_Creator_Username">
+                    </ReportField>
+                    <ReportField Name="CreatedByID_description">
+                    </ReportField>
+                    <ReportField Name="CreatedByScreenID">
+                    </ReportField>
+                    <ReportField Name="CreatedDateTime">
+                        <DataType>DateTime</DataType>
+                    </ReportField>
+                    <ReportField Name="CreatedDateTime_Day">
+                    </ReportField>
+                    <ReportField Name="CreatedDateTime_Hour">
+                    </ReportField>
+                    <ReportField Name="CreatedDateTime_Month">
+                    </ReportField>
+                    <ReportField Name="CreatedDateTime_Quarter">
+                    </ReportField>
+                    <ReportField Name="CycleID">
+                    </ReportField>
+                    <ReportField Name="CycleID_description">
+                    </ReportField>
+                    <ReportField Name="CycleID_INPICycle_descr">
+                    </ReportField>
+                    <ReportField Name="DecimalBaseUnit">
+                        <DataType>Boolean</DataType>
+                    </ReportField>
+                    <ReportField Name="DecimalPurchaseUnit">
+                        <DataType>Boolean</DataType>
+                    </ReportField>
+                    <ReportField Name="DecimalSalesUnit">
+                        <DataType>Boolean</DataType>
+                    </ReportField>
+                    <ReportField Name="DefaultColumnMatrixAttributeID">
+                    </ReportField>
+                    <ReportField Name="DefaultColumnMatrixAttributeID_CSAttribute_description">
+                    </ReportField>
+                    <ReportField Name="DefaultColumnMatrixAttributeID_description">
+                    </ReportField>
+                    <ReportField Name="DefaultRowMatrixAttributeID">
+                    </ReportField>
+                    <ReportField Name="DefaultRowMatrixAttributeID_CSAttribute_description">
+                    </ReportField>
+                    <ReportField Name="DefaultRowMatrixAttributeID_description">
+                    </ReportField>
+                    <ReportField Name="DefaultSubItemID">
+                    </ReportField>
+                    <ReportField Name="DefaultSubItemID_Segment1">
+                    </ReportField>
+                    <ReportField Name="DefaultSubItemOnEntry">
+                        <DataType>Boolean</DataType>
+                    </ReportField>
+                    <ReportField Name="DefaultTerm">
+                        <DataType>Decimal</DataType>
+                    </ReportField>
+                    <ReportField Name="DefaultTermUOM">
+                    </ReportField>
+                    <ReportField Name="DeferralAcctID">
+                    </ReportField>
+                    <ReportField Name="DeferralAcctID_Account_description">
+                    </ReportField>
+                    <ReportField Name="DeferralAcctID_description">
+                    </ReportField>
+                    <ReportField Name="DeferralAcctID_Segment1">
+                    </ReportField>
+                    <ReportField Name="DeferralSubID">
+                    </ReportField>
+                    <ReportField Name="DeferralSubID_description">
+                    </ReportField>
+                    <ReportField Name="DeferralSubID_Segment1">
+                    </ReportField>
+                    <ReportField Name="DeferralSubID_Segment2">
+                    </ReportField>
+                    <ReportField Name="DeferralSubID_Sub_description">
+                    </ReportField>
+                    <ReportField Name="DeferredCode">
+                    </ReportField>
+                    <ReportField Name="Descr">
+                    </ReportField>
+                    <ReportField Name="DfltReceiptLocationID">
+                    </ReportField>
+                    <ReportField Name="DfltReceiptLocationID_description">
+                    </ReportField>
+                    <ReportField Name="DfltReceiptLocationID_INLocation_descr">
+                    </ReportField>
+                    <ReportField Name="DfltReceiptLocationID_Segment1">
+                    </ReportField>
+                    <ReportField Name="DfltShipLocationID">
+                    </ReportField>
+                    <ReportField Name="DfltShipLocationID_description">
+                    </ReportField>
+                    <ReportField Name="DfltShipLocationID_INLocation_descr">
+                    </ReportField>
+                    <ReportField Name="DfltShipLocationID_Segment1">
+                    </ReportField>
+                    <ReportField Name="DfltSiteID">
+                    </ReportField>
+                    <ReportField Name="DfltSiteID_description">
+                    </ReportField>
+                    <ReportField Name="DfltSiteID_INSite_descr">
+                    </ReportField>
+                    <ReportField Name="DfltSiteID_Segment1">
+                    </ReportField>
+                    <ReportField Name="DiscAcctID">
+                        <DataType>Int32</DataType>
+                    </ReportField>
+                    <ReportField Name="DiscSubID">
+                        <DataType>Int32</DataType>
+                    </ReportField>
+                    <ReportField Name="EarningsAcctID">
+                    </ReportField>
+                    <ReportField Name="EarningsAcctID_Account_description">
+                    </ReportField>
+                    <ReportField Name="EarningsAcctID_description">
+                    </ReportField>
+                    <ReportField Name="EarningsAcctID_Segment1">
+                    </ReportField>
+                    <ReportField Name="EarningsSubID">
+                    </ReportField>
+                    <ReportField Name="EarningsSubID_description">
+                    </ReportField>
+                    <ReportField Name="EarningsSubID_Segment1">
+                    </ReportField>
+                    <ReportField Name="EarningsSubID_Segment2">
+                    </ReportField>
+                    <ReportField Name="EarningsSubID_Sub_description">
+                    </ReportField>
+                    <ReportField Name="EntityTypeID">
+                        <DataType>Int32</DataType>
+                    </ReportField>
+                    <ReportField Name="ExpenseAccrualAcctID">
+                        <DataType>Int32</DataType>
+                    </ReportField>
+                    <ReportField Name="ExpenseAccrualSubID">
+                        <DataType>Int32</DataType>
+                    </ReportField>
+                    <ReportField Name="ExpenseAcctID">
+                        <DataType>Int32</DataType>
+                    </ReportField>
+                    <ReportField Name="ExpenseSubID">
+                        <DataType>Int32</DataType>
+                    </ReportField>
+                    <ReportField Name="ExportToExternal">
+                        <DataType>Boolean</DataType>
+                    </ReportField>
+                    <ReportField Name="GenerationRuleCntr">
+                        <DataType>Int32</DataType>
+                    </ReportField>
+                    <ReportField Name="GroupMask">
+                        <DataType>Object</DataType>
+                    </ReportField>
+                    <ReportField Name="HasChild">
+                        <DataType>Boolean</DataType>
+                    </ReportField>
+                    <ReportField Name="HSTariffCode">
+                    </ReportField>
+                    <ReportField Name="ImageUrl">
+                    </ReportField>
+                    <ReportField Name="Included">
+                        <DataType>Boolean</DataType>
+                    </ReportField>
+                    <ReportField Name="InventoryCD">
+                    </ReportField>
+                    <ReportField Name="InventoryCD_Segment1">
+                    </ReportField>
+                    <ReportField Name="InventoryID">
+                        <DataType>Int32</DataType>
+                    </ReportField>
+                    <ReportField Name="InvtAcctID">
+                    </ReportField>
+                    <ReportField Name="InvtAcctID_Account_description">
+                    </ReportField>
+                    <ReportField Name="InvtAcctID_description">
+                    </ReportField>
+                    <ReportField Name="InvtAcctID_Segment1">
+                    </ReportField>
+                    <ReportField Name="InvtSubID">
+                    </ReportField>
+                    <ReportField Name="InvtSubID_description">
+                    </ReportField>
+                    <ReportField Name="InvtSubID_Segment1">
+                    </ReportField>
+                    <ReportField Name="InvtSubID_Segment2">
+                    </ReportField>
+                    <ReportField Name="InvtSubID_Sub_description">
+                    </ReportField>
+                    <ReportField Name="IsSplitted">
+                        <DataType>Boolean</DataType>
+                    </ReportField>
+                    <ReportField Name="IsTemplate">
+                        <DataType>Boolean</DataType>
+                    </ReportField>
+                    <ReportField Name="ItemClassID">
+                    </ReportField>
+                    <ReportField Name="ItemClassID_description">
+                    </ReportField>
+                    <ReportField Name="ItemClassID_INItemClass_descr">
+                    </ReportField>
+                    <ReportField Name="ItemClassID_Segment1">
+                    </ReportField>
+                    <ReportField Name="ItemClassID_Segment2">
+                    </ReportField>
+                    <ReportField Name="ItemClassID_Segment3">
+                    </ReportField>
+                    <ReportField Name="ItemStatus">
+                    </ReportField>
+                    <ReportField Name="ItemType">
+                    </ReportField>
+                    <ReportField Name="KitItem">
+                        <DataType>Boolean</DataType>
+                    </ReportField>
+                    <ReportField Name="LastModifiedByID">
+                    </ReportField>
+                    <ReportField Name="LastModifiedByID_description">
+                    </ReportField>
+                    <ReportField Name="LastModifiedByID_Modifier_displayName">
+                    </ReportField>
+                    <ReportField Name="LastModifiedByID_Modifier_Username">
+                    </ReportField>
+                    <ReportField Name="LastModifiedByScreenID">
+                    </ReportField>
+                    <ReportField Name="LastModifiedDateTime">
+                        <DataType>DateTime</DataType>
+                    </ReportField>
+                    <ReportField Name="LastModifiedDateTime_Day">
+                    </ReportField>
+                    <ReportField Name="LastModifiedDateTime_Hour">
+                    </ReportField>
+                    <ReportField Name="LastModifiedDateTime_Month">
+                    </ReportField>
+                    <ReportField Name="LastModifiedDateTime_Quarter">
+                    </ReportField>
+                    <ReportField Name="LastSiteID">
+                        <DataType>Int32</DataType>
+                    </ReportField>
+                    <ReportField Name="LastStdCost">
+                        <DataType>Decimal</DataType>
+                    </ReportField>
+                    <ReportField Name="LCVarianceAcctID">
+                    </ReportField>
+                    <ReportField Name="LCVarianceAcctID_Account_description">
+                    </ReportField>
+                    <ReportField Name="LCVarianceAcctID_description">
+                    </ReportField>
+                    <ReportField Name="LCVarianceAcctID_Segment1">
+                    </ReportField>
+                    <ReportField Name="LCVarianceSubID">
+                    </ReportField>
+                    <ReportField Name="LCVarianceSubID_description">
+                    </ReportField>
+                    <ReportField Name="LCVarianceSubID_Segment1">
+                    </ReportField>
+                    <ReportField Name="LCVarianceSubID_Segment2">
+                    </ReportField>
+                    <ReportField Name="LCVarianceSubID_Sub_description">
+                    </ReportField>
+                    <ReportField Name="LotSerClassID">
+                    </ReportField>
+                    <ReportField Name="LotSerClassID_description">
+                    </ReportField>
+                    <ReportField Name="LotSerClassID_INLotSerClass_descr">
+                    </ReportField>
+                    <ReportField Name="MarkupPct">
+                        <DataType>Decimal</DataType>
+                    </ReportField>
+                    <ReportField Name="MinGrossProfitPct">
+                        <DataType>Decimal</DataType>
+                    </ReportField>
+                    <ReportField Name="MovementClassID">
+                    </ReportField>
+                    <ReportField Name="MovementClassID_description">
+                    </ReportField>
+                    <ReportField Name="MovementClassID_INMovementClass_descr">
+                    </ReportField>
+                    <ReportField Name="MovementClassIsFixed">
+                        <DataType>Boolean</DataType>
+                    </ReportField>
+                    <ReportField Name="NegQty">
+                        <DataType>Boolean</DataType>
+                    </ReportField>
+                    <ReportField Name="NonStockReceipt">
+                        <DataType>Boolean</DataType>
+                    </ReportField>
+                    <ReportField Name="NonStockReceiptAsService">
+                        <DataType>Boolean</DataType>
+                    </ReportField>
+                    <ReportField Name="NonStockShip">
+                        <DataType>Boolean</DataType>
+                    </ReportField>
+                    <ReportField Name="NotAvailMode">
+                    </ReportField>
+                    <ReportField Name="NoteActivity">
+                    </ReportField>
+                    <ReportField Name="NoteFiles">
+                    </ReportField>
+                    <ReportField Name="NoteID">
+                        <DataType>Object</DataType>
+                    </ReportField>
+                    <ReportField Name="NoteImages">
+                    </ReportField>
+                    <ReportField Name="NotePopupText">
+                    </ReportField>
+                    <ReportField Name="NoteText">
+                    </ReportField>
+                    <ReportField Name="OrigLotSerClassID">
+                    </ReportField>
+                    <ReportField Name="OvershipThreshold">
+                        <DataType>Decimal</DataType>
+                    </ReportField>
+                    <ReportField Name="PackageOption">
+                    </ReportField>
+                    <ReportField Name="PackSeparately">
+                        <DataType>Boolean</DataType>
+                    </ReportField>
+                    <ReportField Name="ParentItemClassID">
+                        <DataType>Int32</DataType>
+                    </ReportField>
+                    <ReportField Name="PendingStdCost">
+                        <DataType>Decimal</DataType>
+                    </ReportField>
+                    <ReportField Name="PendingStdCostDate">
+                        <DataType>DateTime</DataType>
+                    </ReportField>
+                    <ReportField Name="PendingStdCostDate_Day">
+                    </ReportField>
+                    <ReportField Name="PendingStdCostDate_Hour">
+                    </ReportField>
+                    <ReportField Name="PendingStdCostDate_Month">
+                    </ReportField>
+                    <ReportField Name="PendingStdCostDate_Quarter">
+                    </ReportField>
+                    <ReportField Name="PercentOfSalesPrice">
+                        <DataType>Decimal</DataType>
+                    </ReportField>
+                    <ReportField Name="PIXELSIZE_Attributes">
+                    </ReportField>
+                    <ReportField Name="POAccrualAcctID">
+                    </ReportField>
+                    <ReportField Name="POAccrualAcctID_Account_description">
+                    </ReportField>
+                    <ReportField Name="POAccrualAcctID_description">
+                    </ReportField>
+                    <ReportField Name="POAccrualAcctID_Segment1">
+                    </ReportField>
+                    <ReportField Name="POAccrualSubID">
+                    </ReportField>
+                    <ReportField Name="POAccrualSubID_description">
+                    </ReportField>
+                    <ReportField Name="POAccrualSubID_Segment1">
+                    </ReportField>
+                    <ReportField Name="POAccrualSubID_Segment2">
+                    </ReportField>
+                    <ReportField Name="POAccrualSubID_Sub_description">
+                    </ReportField>
+                    <ReportField Name="PostClassID">
+                    </ReportField>
+                    <ReportField Name="PPVAcctID">
+                    </ReportField>
+                    <ReportField Name="PPVAcctID_Account_description">
+                    </ReportField>
+                    <ReportField Name="PPVAcctID_description">
+                    </ReportField>
+                    <ReportField Name="PPVAcctID_Segment1">
+                    </ReportField>
+                    <ReportField Name="PPVSubID">
+                    </ReportField>
+                    <ReportField Name="PPVSubID_description">
+                    </ReportField>
+                    <ReportField Name="PPVSubID_Segment1">
+                    </ReportField>
+                    <ReportField Name="PPVSubID_Segment2">
+                    </ReportField>
+                    <ReportField Name="PPVSubID_Sub_description">
+                    </ReportField>
+                    <ReportField Name="PreferredVendorID">
+                    </ReportField>
+                    <ReportField Name="PreferredVendorID_BAccountR_acctName">
+                    </ReportField>
+                    <ReportField Name="PreferredVendorID_description">
+                    </ReportField>
+                    <ReportField Name="PreferredVendorID_Segment1">
+                    </ReportField>
+                    <ReportField Name="PreferredVendorID_Vendor_acctName">
+                    </ReportField>
+                    <ReportField Name="PreferredVendorLocationID">
+                    </ReportField>
+                    <ReportField Name="PreferredVendorLocationID_description">
+                    </ReportField>
+                    <ReportField Name="PreferredVendorLocationID_Location_descr">
+                    </ReportField>
+                    <ReportField Name="PreferredVendorLocationID_Segment1">
+                    </ReportField>
+                    <ReportField Name="PriceClassID">
+                    </ReportField>
+                    <ReportField Name="PriceClassID_description">
+                    </ReportField>
+                    <ReportField Name="PriceClassID_INPriceClass_description">
+                    </ReportField>
+                    <ReportField Name="PriceManagerID">
+                        <DataType>Int32</DataType>
+                    </ReportField>
+                    <ReportField Name="PriceManagerID_description">
+                    </ReportField>
+                    <ReportField Name="PriceManagerID_Owner_displayName">
+                    </ReportField>
+                    <ReportField Name="PriceWorkgroupID">
+                    </ReportField>
+                    <ReportField Name="ProductManagerID">
+                        <DataType>Int32</DataType>
+                    </ReportField>
+                    <ReportField Name="ProductManagerID_description">
+                    </ReportField>
+                    <ReportField Name="ProductManagerID_Owner_displayName">
+                    </ReportField>
+                    <ReportField Name="ProductWorkgroupID">
+                    </ReportField>
+                    <ReportField Name="PTOExpenseAcctID">
+                    </ReportField>
+                    <ReportField Name="PTOExpenseAcctID_Account_description">
+                    </ReportField>
+                    <ReportField Name="PTOExpenseAcctID_description">
+                    </ReportField>
+                    <ReportField Name="PTOExpenseAcctID_Segment1">
+                    </ReportField>
+                    <ReportField Name="PTOExpenseSubID">
+                    </ReportField>
+                    <ReportField Name="PTOExpenseSubID_description">
+                    </ReportField>
+                    <ReportField Name="PTOExpenseSubID_Segment1">
+                    </ReportField>
+                    <ReportField Name="PTOExpenseSubID_Segment2">
+                    </ReportField>
+                    <ReportField Name="PTOExpenseSubID_Sub_description">
+                    </ReportField>
+                    <ReportField Name="PurchaseUnit">
+                    </ReportField>
+                    <ReportField Name="ReasonCodeSubID">
+                    </ReportField>
+                    <ReportField Name="ReasonCodeSubID_description">
+                    </ReportField>
+                    <ReportField Name="ReasonCodeSubID_Segment1">
+                    </ReportField>
+                    <ReportField Name="ReasonCodeSubID_Segment2">
+                    </ReportField>
+                    <ReportField Name="ReasonCodeSubID_Sub_description">
+                    </ReportField>
+                    <ReportField Name="RecPrice">
+                        <DataType>Decimal</DataType>
+                    </ReportField>
+                    <ReportField Name="RESOHM_Attributes">
+                    </ReportField>
+                    <ReportField Name="RESPOWER_Attributes">
+                    </ReportField>
+                    <ReportField Name="RESTOL_Attributes">
+                    </ReportField>
+                    <ReportField Name="RowAttributeValue">
+                    </ReportField>
+                    <ReportField Name="SalesAcctID">
+                    </ReportField>
+                    <ReportField Name="SalesAcctID_Account_description">
+                    </ReportField>
+                    <ReportField Name="SalesAcctID_description">
+                    </ReportField>
+                    <ReportField Name="SalesAcctID_Segment1">
+                    </ReportField>
+                    <ReportField Name="SalesSubID">
+                    </ReportField>
+                    <ReportField Name="SalesSubID_description">
+                    </ReportField>
+                    <ReportField Name="SalesSubID_Segment1">
+                    </ReportField>
+                    <ReportField Name="SalesSubID_Segment2">
+                    </ReportField>
+                    <ReportField Name="SalesSubID_Sub_description">
+                    </ReportField>
+                    <ReportField Name="SalesUnit">
+                    </ReportField>
+                    <ReportField Name="SampleDescription">
+                    </ReportField>
+                    <ReportField Name="SampleID">
+                    </ReportField>
+                    <ReportField Name="Secured">
+                        <DataType>Boolean</DataType>
+                    </ReportField>
+                    <ReportField Name="Selected">
+                        <DataType>Boolean</DataType>
+                    </ReportField>
+                    <ReportField Name="SIZESHIRT_Attributes">
+                    </ReportField>
+                    <ReportField Name="StdCost">
+                        <DataType>Decimal</DataType>
+                    </ReportField>
+                    <ReportField Name="StdCostDate">
+                        <DataType>DateTime</DataType>
+                    </ReportField>
+                    <ReportField Name="StdCostDate_Day">
+                    </ReportField>
+                    <ReportField Name="StdCostDate_Hour">
+                    </ReportField>
+                    <ReportField Name="StdCostDate_Month">
+                    </ReportField>
+                    <ReportField Name="StdCostDate_Quarter">
+                    </ReportField>
+                    <ReportField Name="StdCstRevAcctID">
+                    </ReportField>
+                    <ReportField Name="StdCstRevAcctID_Account_description">
+                    </ReportField>
+                    <ReportField Name="StdCstRevAcctID_description">
+                    </ReportField>
+                    <ReportField Name="StdCstRevAcctID_Segment1">
+                    </ReportField>
+                    <ReportField Name="StdCstRevSubID">
+                    </ReportField>
+                    <ReportField Name="StdCstRevSubID_description">
+                    </ReportField>
+                    <ReportField Name="StdCstRevSubID_Segment1">
+                    </ReportField>
+                    <ReportField Name="StdCstRevSubID_Segment2">
+                    </ReportField>
+                    <ReportField Name="StdCstRevSubID_Sub_description">
+                    </ReportField>
+                    <ReportField Name="StdCstVarAcctID">
+                    </ReportField>
+                    <ReportField Name="StdCstVarAcctID_Account_description">
+                    </ReportField>
+                    <ReportField Name="StdCstVarAcctID_description">
+                    </ReportField>
+                    <ReportField Name="StdCstVarAcctID_Segment1">
+                    </ReportField>
+                    <ReportField Name="StdCstVarSubID">
+                    </ReportField>
+                    <ReportField Name="StdCstVarSubID_description">
+                    </ReportField>
+                    <ReportField Name="StdCstVarSubID_Segment1">
+                    </ReportField>
+                    <ReportField Name="StdCstVarSubID_Segment2">
+                    </ReportField>
+                    <ReportField Name="StdCstVarSubID_Sub_description">
+                    </ReportField>
+                    <ReportField Name="StkItem">
+                        <DataType>Boolean</DataType>
+                    </ReportField>
+                    <ReportField Name="TaxCalcMode">
+                    </ReportField>
+                    <ReportField Name="TaxCategoryID">
+                    </ReportField>
+                    <ReportField Name="TaxCategoryID_description">
+                    </ReportField>
+                    <ReportField Name="TaxCategoryID_TaxCategory_descr">
+                    </ReportField>
+                    <ReportField Name="TaxExpenseAcctID">
+                    </ReportField>
+                    <ReportField Name="TaxExpenseAcctID_Account_description">
+                    </ReportField>
+                    <ReportField Name="TaxExpenseAcctID_description">
+                    </ReportField>
+                    <ReportField Name="TaxExpenseAcctID_Segment1">
+                    </ReportField>
+                    <ReportField Name="TaxExpenseSubID">
+                    </ReportField>
+                    <ReportField Name="TaxExpenseSubID_description">
+                    </ReportField>
+                    <ReportField Name="TaxExpenseSubID_Segment1">
+                    </ReportField>
+                    <ReportField Name="TaxExpenseSubID_Segment2">
+                    </ReportField>
+                    <ReportField Name="TaxExpenseSubID_Sub_description">
+                    </ReportField>
+                    <ReportField Name="TemplateItemID">
+                    </ReportField>
+                    <ReportField Name="TemplateItemID_description">
+                    </ReportField>
+                    <ReportField Name="TemplateItemID_InventoryItem_descr">
+                    </ReportField>
+                    <ReportField Name="TemplateItemID_Segment1">
+                    </ReportField>
+                    <ReportField Name="TotalPercentage">
+                        <DataType>Decimal</DataType>
+                    </ReportField>
+                    <ReportField Name="tstamp">
+                    </ReportField>
+                    <ReportField Name="UndershipThreshold">
+                        <DataType>Decimal</DataType>
+                    </ReportField>
+                    <ReportField Name="UpdateOnlySelected">
+                        <DataType>Boolean</DataType>
+                    </ReportField>
+                    <ReportField Name="UseParentSubID">
+                        <DataType>Boolean</DataType>
+                    </ReportField>
+                    <ReportField Name="ValMethod">
+                    </ReportField>
+                    <ReportField Name="Visibility">
+                    </ReportField>
+                    <ReportField Name="VolumeUOM">
+                    </ReportField>
+                    <ReportField Name="WeightItem">
+                        <DataType>Boolean</DataType>
+                    </ReportField>
+                    <ReportField Name="WeightUOM">
+                    </ReportField>
+                    <ReportField Name="WIDEANGLE_Attributes">
+                    </ReportField>
+                </Fields>
+                <FullName>PX.Objects.IN.InventoryItem</FullName>
+            </ReportTable>
+        </Tables>
+        <Version>20211215</Version>
+        <Sections>
+            <PageHeader Name="pageHeaderSection1">
+                <Height>1.26984cm</Height>
+                <Items>
+                    <TextBox Name="textBox5">
+                        <Location>0px, 24px</Location>
+                        <Size>120px, 24px</Size>
+                        <Style>
+                            <Font>
+                                <Style>Bold</Style>
+                            </Font>
+                        </Style>
+                        <Value>Inventory ID</Value>
+                    </TextBox>
+                    <TextBox Name="textBox6">
+                        <Location>128px, 24px</Location>
+                        <Size>288px, 24px</Size>
+                        <Style>
+                            <Font>
+                                <Style>Bold</Style>
+                            </Font>
+                        </Style>
+                        <Value>Description</Value>
+                    </TextBox>
+                    <TextBox Name="textBox7">
+                        <Location>424px, 24px</Location>
+                        <Size>120px, 24px</Size>
+                        <Style>
+                            <Font>
+                                <Style>Bold</Style>
+                            </Font>
+                        </Style>
+                        <Value>Quantity</Value>
+                    </TextBox>
+                    <TextBox Name="textBox8">
+                        <Location>568px, 24px</Location>
+                        <Size>120px, 24px</Size>
+                        <Style>
+                            <Font>
+                                <Style>Bold</Style>
+                            </Font>
+                        </Style>
+                        <Value>Criticality</Value>
+                    </TextBox>
+                    <TextBox Name="textBox9">
+                        <Location>0px, 0px</Location>
+                        <Size>120px, 24px</Size>
+                        <Style>
+                            <Font>
+                                <Style>Bold, Underline</Style>
+                            </Font>
+                        </Style>
+                        <Value>Bill of Materials</Value>
+                    </TextBox>
+                </Items>
+            </PageHeader>
+            <Detail Name="detailSection1">
+                <Height>0.84656cm</Height>
+                <Items>
+                    <TextBox Name="textBox1">
+                        <Location>0px, 0px</Location>
+                        <Size>120px, 24px</Size>
+                        <Value>=[WOEquipmentBOM.InventoryID]</Value>
+                    </TextBox>
+                    <TextBox Name="textBox2">
+                        <Location>424px, 0px</Location>
+                        <Size>120px, 24px</Size>
+                        <Value>=[WOEquipmentBOM.Quantity]</Value>
+                    </TextBox>
+                    <TextBox Name="textBox3">
+                        <Location>568px, 0px</Location>
+                        <Size>120px, 24px</Size>
+                        <Value>=[WOEquipmentBOM.Criticality]</Value>
+                    </TextBox>
+                    <TextBox Name="textBox4">
+                        <Location>128px, 0px</Location>
+                        <Size>288px, 24px</Size>
+                        <Value>=[InventoryItem.Descr]</Value>
+                    </TextBox>
+                </Items>
+            </Detail>
+            <PageFooter Name="pageFooterSection1">
+                <Expanded>False</Expanded>
+                <Height>0.21164cm</Height>
+            </PageFooter>
+        </Sections>
+    </Report>
+</Report>

--- a/Package/CMMS/_project/REPORT_WO601002_RPX.xml
+++ b/Package/CMMS/_project/REPORT_WO601002_RPX.xml
@@ -1,0 +1,218 @@
+﻿<Report Name="wo601002.rpx">
+    <Report version="20211215" Name="report1">
+        <Filters>
+            <FilterExp>
+                <DataField>WOEquipmentFM.EquipmentID</DataField>
+                <Value>@EquipmentID</Value>
+            </FilterExp>
+        </Filters>
+        <Parameters>
+            <ReportParameter>
+                <Name>EquipmentID</Name>
+            </ReportParameter>
+        </Parameters>
+        <Relations>
+            <ReportRelation>
+                <ChildName>WOFailureMode</ChildName>
+                <Links>
+                    <RelationRow>
+                        <ChildField>FailureModeID</ChildField>
+                        <ParentField>FailureModeID</ParentField>
+                    </RelationRow>
+                </Links>
+                <ParentName>WOEquipmentFM</ParentName>
+            </ReportRelation>
+        </Relations>
+        <SchemaUrl>http://localhost/CMMS</SchemaUrl>
+        <Tables>
+            <ReportTable Name="WOEquipmentFM">
+                <Fields>
+                    <ReportField Name="CreatedByID">
+                    </ReportField>
+                    <ReportField Name="CreatedByID_Creator_displayName">
+                    </ReportField>
+                    <ReportField Name="CreatedByID_Creator_Username">
+                    </ReportField>
+                    <ReportField Name="CreatedByID_description">
+                    </ReportField>
+                    <ReportField Name="CreatedByScreenID">
+                    </ReportField>
+                    <ReportField Name="CreatedDateTime">
+                        <DataType>DateTime</DataType>
+                    </ReportField>
+                    <ReportField Name="CreatedDateTime_Day">
+                    </ReportField>
+                    <ReportField Name="CreatedDateTime_Hour">
+                    </ReportField>
+                    <ReportField Name="CreatedDateTime_Month">
+                    </ReportField>
+                    <ReportField Name="CreatedDateTime_Quarter">
+                    </ReportField>
+                    <ReportField Name="EquipmentID">
+                    </ReportField>
+                    <ReportField Name="FailureModeID">
+                        <DataType>Int32</DataType>
+                    </ReportField>
+                    <ReportField Name="LastModifiedByID">
+                    </ReportField>
+                    <ReportField Name="LastModifiedByID_description">
+                    </ReportField>
+                    <ReportField Name="LastModifiedByID_Modifier_displayName">
+                    </ReportField>
+                    <ReportField Name="LastModifiedByID_Modifier_Username">
+                    </ReportField>
+                    <ReportField Name="LastModifiedByScreenID">
+                    </ReportField>
+                    <ReportField Name="LastModifiedDateTime">
+                        <DataType>DateTime</DataType>
+                    </ReportField>
+                    <ReportField Name="LastModifiedDateTime_Day">
+                    </ReportField>
+                    <ReportField Name="LastModifiedDateTime_Hour">
+                    </ReportField>
+                    <ReportField Name="LastModifiedDateTime_Month">
+                    </ReportField>
+                    <ReportField Name="LastModifiedDateTime_Quarter">
+                    </ReportField>
+                    <ReportField Name="NoteActivity">
+                    </ReportField>
+                    <ReportField Name="NoteFiles">
+                    </ReportField>
+                    <ReportField Name="NoteID">
+                        <DataType>Object</DataType>
+                    </ReportField>
+                    <ReportField Name="NoteImages">
+                    </ReportField>
+                    <ReportField Name="NoteText">
+                    </ReportField>
+                    <ReportField Name="Tstamp">
+                    </ReportField>
+                </Fields>
+                <FullName>CMMSlite.WO.WOEquipmentFM</FullName>
+            </ReportTable>
+            <ReportTable Name="WOFailureMode">
+                <Fields>
+                    <ReportField Name="CreatedByID">
+                    </ReportField>
+                    <ReportField Name="CreatedByID_Creator_displayName">
+                    </ReportField>
+                    <ReportField Name="CreatedByID_Creator_Username">
+                    </ReportField>
+                    <ReportField Name="CreatedByID_description">
+                    </ReportField>
+                    <ReportField Name="CreatedByScreenID">
+                    </ReportField>
+                    <ReportField Name="CreatedDateTime">
+                        <DataType>DateTime</DataType>
+                    </ReportField>
+                    <ReportField Name="CreatedDateTime_Day">
+                    </ReportField>
+                    <ReportField Name="CreatedDateTime_Hour">
+                    </ReportField>
+                    <ReportField Name="CreatedDateTime_Month">
+                    </ReportField>
+                    <ReportField Name="CreatedDateTime_Quarter">
+                    </ReportField>
+                    <ReportField Name="Descr">
+                    </ReportField>
+                    <ReportField Name="FailureModeCD">
+                    </ReportField>
+                    <ReportField Name="FailureModeID">
+                        <DataType>Int32</DataType>
+                    </ReportField>
+                    <ReportField Name="LastModifiedByID">
+                    </ReportField>
+                    <ReportField Name="LastModifiedByID_description">
+                    </ReportField>
+                    <ReportField Name="LastModifiedByID_Modifier_displayName">
+                    </ReportField>
+                    <ReportField Name="LastModifiedByID_Modifier_Username">
+                    </ReportField>
+                    <ReportField Name="LastModifiedByScreenID">
+                    </ReportField>
+                    <ReportField Name="LastModifiedDateTime">
+                        <DataType>DateTime</DataType>
+                    </ReportField>
+                    <ReportField Name="LastModifiedDateTime_Day">
+                    </ReportField>
+                    <ReportField Name="LastModifiedDateTime_Hour">
+                    </ReportField>
+                    <ReportField Name="LastModifiedDateTime_Month">
+                    </ReportField>
+                    <ReportField Name="LastModifiedDateTime_Quarter">
+                    </ReportField>
+                    <ReportField Name="NoteActivity">
+                    </ReportField>
+                    <ReportField Name="NoteFiles">
+                    </ReportField>
+                    <ReportField Name="NoteID">
+                        <DataType>Object</DataType>
+                    </ReportField>
+                    <ReportField Name="NoteImages">
+                    </ReportField>
+                    <ReportField Name="NoteText">
+                    </ReportField>
+                    <ReportField Name="Tstamp">
+                    </ReportField>
+                </Fields>
+                <FullName>CMMSlite.WOFailureMode</FullName>
+            </ReportTable>
+        </Tables>
+        <Version>20211215</Version>
+        <Sections>
+            <PageHeader Name="pageHeaderSection1">
+                <Height>1.26984cm</Height>
+                <Items>
+                    <TextBox Name="textBox5">
+                        <Location>0px, 24px</Location>
+                        <Size>120px, 24px</Size>
+                        <Style>
+                            <Font>
+                                <Style>Bold</Style>
+                            </Font>
+                        </Style>
+                        <Value>Failure Mode</Value>
+                    </TextBox>
+                    <TextBox Name="textBox6">
+                        <Location>128px, 24px</Location>
+                        <Size>560px, 24px</Size>
+                        <Style>
+                            <Font>
+                                <Style>Bold</Style>
+                            </Font>
+                        </Style>
+                        <Value>Description</Value>
+                    </TextBox>
+                    <TextBox Name="textBox9">
+                        <Location>0px, 0px</Location>
+                        <Size>120px, 24px</Size>
+                        <Style>
+                            <Font>
+                                <Style>Bold, Underline</Style>
+                            </Font>
+                        </Style>
+                        <Value>Failure Modes</Value>
+                    </TextBox>
+                </Items>
+            </PageHeader>
+            <Detail Name="detailSection1">
+                <Height>0.84656cm</Height>
+                <Items>
+                    <TextBox Name="textBox1">
+                        <Location>0px, 0px</Location>
+                        <Size>120px, 24px</Size>
+                        <Value>=[WOEquipmentFM.FailureModeID]</Value>
+                    </TextBox>
+                    <TextBox Name="textBox2">
+                        <Location>128px, 0px</Location>
+                        <Size>560px, 24px</Size>
+                        <Value>=[WOFailureMode.Descr]</Value>
+                    </TextBox>
+                </Items>
+            </Detail>
+            <PageFooter Name="pageFooterSection1">
+                <Height>0.21164cm</Height>
+            </PageFooter>
+        </Sections>
+    </Report>
+</Report>

--- a/Package/CMMS/_project/REPORT_WO601003_RPX.xml
+++ b/Package/CMMS/_project/REPORT_WO601003_RPX.xml
@@ -1,0 +1,389 @@
+﻿<Report Name="wo601003.rpx">
+    <Report version="20211215" Name="report1">
+        <Filters>
+            <FilterExp>
+                <DataField>WOSchedule.EquipmentID</DataField>
+                <Value>@EquipmentID</Value>
+            </FilterExp>
+        </Filters>
+        <Parameters>
+            <ReportParameter>
+                <Name>EquipmentID</Name>
+            </ReportParameter>
+        </Parameters>
+        <Relations>
+            <ReportRelation>
+                <ChildName>WOOrder</ChildName>
+                <Links>
+                    <RelationRow>
+                        <ChildField>WorkOrderID</ChildField>
+                        <ParentField>WorkOrderID</ParentField>
+                    </RelationRow>
+                </Links>
+                <ParentName>WOSchedule</ParentName>
+            </ReportRelation>
+        </Relations>
+        <SchemaUrl>http://localhost/CMMS</SchemaUrl>
+        <Tables>
+            <ReportTable Name="WOSchedule">
+                <Fields>
+                    <ReportField Name="CreatedByID">
+                    </ReportField>
+                    <ReportField Name="CreatedByID_Creator_displayName">
+                    </ReportField>
+                    <ReportField Name="CreatedByID_Creator_Username">
+                    </ReportField>
+                    <ReportField Name="CreatedByID_description">
+                    </ReportField>
+                    <ReportField Name="CreatedByScreenID">
+                    </ReportField>
+                    <ReportField Name="CreatedDateTime">
+                        <DataType>DateTime</DataType>
+                    </ReportField>
+                    <ReportField Name="CreatedDateTime_Day">
+                    </ReportField>
+                    <ReportField Name="CreatedDateTime_Hour">
+                    </ReportField>
+                    <ReportField Name="CreatedDateTime_Month">
+                    </ReportField>
+                    <ReportField Name="CreatedDateTime_Quarter">
+                    </ReportField>
+                    <ReportField Name="EquipmentID">
+                        <DataType>Int32</DataType>
+                    </ReportField>
+                    <ReportField Name="FrequencyDays">
+                        <DataType>Int32</DataType>
+                    </ReportField>
+                    <ReportField Name="LastModifiedByID">
+                    </ReportField>
+                    <ReportField Name="LastModifiedByID_description">
+                    </ReportField>
+                    <ReportField Name="LastModifiedByID_Modifier_displayName">
+                    </ReportField>
+                    <ReportField Name="LastModifiedByID_Modifier_Username">
+                    </ReportField>
+                    <ReportField Name="LastModifiedByScreenID">
+                    </ReportField>
+                    <ReportField Name="LastModifiedDateTime">
+                        <DataType>DateTime</DataType>
+                    </ReportField>
+                    <ReportField Name="LastModifiedDateTime_Day">
+                    </ReportField>
+                    <ReportField Name="LastModifiedDateTime_Hour">
+                    </ReportField>
+                    <ReportField Name="LastModifiedDateTime_Month">
+                    </ReportField>
+                    <ReportField Name="LastModifiedDateTime_Quarter">
+                    </ReportField>
+                    <ReportField Name="LastWODate">
+                        <DataType>DateTime</DataType>
+                    </ReportField>
+                    <ReportField Name="LastWODate_Day">
+                    </ReportField>
+                    <ReportField Name="LastWODate_Hour">
+                    </ReportField>
+                    <ReportField Name="LastWODate_Month">
+                    </ReportField>
+                    <ReportField Name="LastWODate_Quarter">
+                    </ReportField>
+                    <ReportField Name="LeadTimeDays">
+                        <DataType>Int32</DataType>
+                    </ReportField>
+                    <ReportField Name="NextWODate">
+                        <DataType>DateTime</DataType>
+                    </ReportField>
+                    <ReportField Name="NextWODate_Day">
+                    </ReportField>
+                    <ReportField Name="NextWODate_Hour">
+                    </ReportField>
+                    <ReportField Name="NextWODate_Month">
+                    </ReportField>
+                    <ReportField Name="NextWODate_Quarter">
+                    </ReportField>
+                    <ReportField Name="NoteActivity">
+                    </ReportField>
+                    <ReportField Name="NoteFiles">
+                    </ReportField>
+                    <ReportField Name="NoteID">
+                        <DataType>Object</DataType>
+                    </ReportField>
+                    <ReportField Name="NoteImages">
+                    </ReportField>
+                    <ReportField Name="NoteText">
+                    </ReportField>
+                    <ReportField Name="Tstamp">
+                    </ReportField>
+                    <ReportField Name="WorkOrderID">
+                    </ReportField>
+                </Fields>
+                <FullName>CMMSlite.WO.WOSchedule</FullName>
+            </ReportTable>
+            <ReportTable Name="WOOrder">
+                <Fields>
+                    <ReportField Name="AMBATCOLOR_Attributes">
+                    </ReportField>
+                    <ReportField Name="AMBATLEN_Attributes">
+                    </ReportField>
+                    <ReportField Name="AMBATPT_Attributes">
+                    </ReportField>
+                    <ReportField Name="AMBATWGT_Attributes">
+                    </ReportField>
+                    <ReportField Name="Approved">
+                        <DataType>Boolean</DataType>
+                    </ReportField>
+                    <ReportField Name="BranchID">
+                        <DataType>Int32</DataType>
+                    </ReportField>
+                    <ReportField Name="ClassID">
+                    </ReportField>
+                    <ReportField Name="CreatedByID">
+                    </ReportField>
+                    <ReportField Name="CreatedByID_Creator_displayName">
+                    </ReportField>
+                    <ReportField Name="CreatedByID_Creator_Username">
+                    </ReportField>
+                    <ReportField Name="CreatedByID_description">
+                    </ReportField>
+                    <ReportField Name="CreatedByScreenID">
+                    </ReportField>
+                    <ReportField Name="CreatedDateTime">
+                        <DataType>DateTime</DataType>
+                    </ReportField>
+                    <ReportField Name="CreatedDateTime_Day">
+                    </ReportField>
+                    <ReportField Name="CreatedDateTime_Hour">
+                    </ReportField>
+                    <ReportField Name="CreatedDateTime_Month">
+                    </ReportField>
+                    <ReportField Name="CreatedDateTime_Quarter">
+                    </ReportField>
+                    <ReportField Name="Descr">
+                    </ReportField>
+                    <ReportField Name="EquipmentID">
+                    </ReportField>
+                    <ReportField Name="EquipmentID_description">
+                    </ReportField>
+                    <ReportField Name="EquipmentID_WOEquipment_descr">
+                    </ReportField>
+                    <ReportField Name="FSRESOL_Attributes">
+                    </ReportField>
+                    <ReportField Name="HANDS_Attributes">
+                    </ReportField>
+                    <ReportField Name="Hold">
+                        <DataType>Boolean</DataType>
+                    </ReportField>
+                    <ReportField Name="LastLineNbr">
+                        <DataType>Int32</DataType>
+                    </ReportField>
+                    <ReportField Name="LastModifiedByID">
+                    </ReportField>
+                    <ReportField Name="LastModifiedByID_description">
+                    </ReportField>
+                    <ReportField Name="LastModifiedByID_Modifier_displayName">
+                    </ReportField>
+                    <ReportField Name="LastModifiedByID_Modifier_Username">
+                    </ReportField>
+                    <ReportField Name="LastModifiedByScreenID">
+                    </ReportField>
+                    <ReportField Name="LastModifiedDateTime">
+                        <DataType>DateTime</DataType>
+                    </ReportField>
+                    <ReportField Name="LastModifiedDateTime_Day">
+                    </ReportField>
+                    <ReportField Name="LastModifiedDateTime_Hour">
+                    </ReportField>
+                    <ReportField Name="LastModifiedDateTime_Month">
+                    </ReportField>
+                    <ReportField Name="LastModifiedDateTime_Quarter">
+                    </ReportField>
+                    <ReportField Name="NoteActivity">
+                    </ReportField>
+                    <ReportField Name="NoteFiles">
+                    </ReportField>
+                    <ReportField Name="NoteID">
+                        <DataType>Object</DataType>
+                    </ReportField>
+                    <ReportField Name="NoteImages">
+                    </ReportField>
+                    <ReportField Name="NoteText">
+                    </ReportField>
+                    <ReportField Name="OrigWorkOrderID">
+                        <DataType>Int32</DataType>
+                    </ReportField>
+                    <ReportField Name="OwnerID">
+                        <DataType>Int32</DataType>
+                    </ReportField>
+                    <ReportField Name="OwnerID_description">
+                    </ReportField>
+                    <ReportField Name="OwnerID_Owner_displayName">
+                    </ReportField>
+                    <ReportField Name="Priority">
+                    </ReportField>
+                    <ReportField Name="Rejected">
+                        <DataType>Boolean</DataType>
+                    </ReportField>
+                    <ReportField Name="RequestApproval">
+                        <DataType>Boolean</DataType>
+                    </ReportField>
+                    <ReportField Name="RequestDate">
+                        <DataType>DateTime</DataType>
+                    </ReportField>
+                    <ReportField Name="RequestDate_Day">
+                    </ReportField>
+                    <ReportField Name="RequestDate_Hour">
+                    </ReportField>
+                    <ReportField Name="RequestDate_Month">
+                    </ReportField>
+                    <ReportField Name="RequestDate_Quarter">
+                    </ReportField>
+                    <ReportField Name="ScheduleDate">
+                        <DataType>DateTime</DataType>
+                    </ReportField>
+                    <ReportField Name="ScheduleDate_Day">
+                    </ReportField>
+                    <ReportField Name="ScheduleDate_Hour">
+                    </ReportField>
+                    <ReportField Name="ScheduleDate_Month">
+                    </ReportField>
+                    <ReportField Name="ScheduleDate_Quarter">
+                    </ReportField>
+                    <ReportField Name="Selected">
+                        <DataType>Boolean</DataType>
+                    </ReportField>
+                    <ReportField Name="Status">
+                    </ReportField>
+                    <ReportField Name="Tstamp">
+                    </ReportField>
+                    <ReportField Name="WOClassID">
+                    </ReportField>
+                    <ReportField Name="WorkgroupID">
+                    </ReportField>
+                    <ReportField Name="WorkOrderCD">
+                    </ReportField>
+                    <ReportField Name="WorkOrderID">
+                        <DataType>Int32</DataType>
+                    </ReportField>
+                    <ReportField Name="WorkOrderType">
+                    </ReportField>
+                </Fields>
+                <FullName>CMMSlite.WO.WOOrder</FullName>
+            </ReportTable>
+        </Tables>
+        <Version>20211215</Version>
+        <Sections>
+            <PageHeader Name="pageHeaderSection1">
+                <Height>1.26984cm</Height>
+                <Items>
+                    <TextBox Name="textBox10">
+                        <Location>128px, 24px</Location>
+                        <Size>192px, 24px</Size>
+                        <Style>
+                            <Font>
+                                <Style>Bold</Style>
+                            </Font>
+                        </Style>
+                        <Value>Description</Value>
+                    </TextBox>
+                    <TextBox Name="textBox11">
+                        <Location>0px, 24px</Location>
+                        <Size>120px, 24px</Size>
+                        <Style>
+                            <Font>
+                                <Style>Bold</Style>
+                            </Font>
+                        </Style>
+                        <Value>Work Order ID</Value>
+                    </TextBox>
+                    <TextBox Name="textBox12">
+                        <Location>480px, 24px</Location>
+                        <Size>64px, 24px</Size>
+                        <Style>
+                            <Font>
+                                <Style>Bold</Style>
+                            </Font>
+                        </Style>
+                        <Value>Last Date</Value>
+                    </TextBox>
+                    <TextBox Name="textBox13">
+                        <Location>568px, 24px</Location>
+                        <Size>64px, 24px</Size>
+                        <Style>
+                            <Font>
+                                <Style>Bold</Style>
+                            </Font>
+                        </Style>
+                        <Value>Next Date</Value>
+                    </TextBox>
+                    <TextBox Name="textBox7">
+                        <Location>328px, 24px</Location>
+                        <Size>72px, 24px</Size>
+                        <Style>
+                            <Font>
+                                <Style>Bold</Style>
+                            </Font>
+                        </Style>
+                        <Value>Lead Time</Value>
+                    </TextBox>
+                    <TextBox Name="textBox8">
+                        <Location>408px, 24px</Location>
+                        <Size>64px, 24px</Size>
+                        <Style>
+                            <Font>
+                                <Style>Bold</Style>
+                            </Font>
+                        </Style>
+                        <Value>Frequency</Value>
+                    </TextBox>
+                    <TextBox Name="textBox9">
+                        <Location>0px, 0px</Location>
+                        <Size>120px, 24px</Size>
+                        <Style>
+                            <Font>
+                                <Style>Bold</Style>
+                            </Font>
+                        </Style>
+                        <Value>Schedules</Value>
+                    </TextBox>
+                </Items>
+            </PageHeader>
+            <Detail Name="detailSection1">
+                <Height>0.84656cm</Height>
+                <Items>
+                    <TextBox Name="textBox1">
+                        <Location>0px, 0px</Location>
+                        <Size>120px, 24px</Size>
+                        <Value>=[WOOrder.WorkOrderCD]</Value>
+                    </TextBox>
+                    <TextBox Name="textBox2">
+                        <Location>128px, 0px</Location>
+                        <Size>192px, 24px</Size>
+                        <Value>=[WOOrder.Descr]</Value>
+                    </TextBox>
+                    <TextBox Name="textBox3">
+                        <Location>408px, 0px</Location>
+                        <Size>64px, 24px</Size>
+                        <Value>=[WOSchedule.FrequencyDays]</Value>
+                    </TextBox>
+                    <TextBox Name="textBox4">
+                        <Location>328px, 0px</Location>
+                        <Size>72px, 24px</Size>
+                        <Value>=[WOSchedule.LeadTimeDays]</Value>
+                    </TextBox>
+                    <TextBox Name="textBox5">
+                        <Location>480px, 0px</Location>
+                        <Size>80px, 24px</Size>
+                        <Value>=[WOSchedule.LastWODate]</Value>
+                    </TextBox>
+                    <TextBox Name="textBox6">
+                        <Location>568px, 0px</Location>
+                        <Size>88px, 24px</Size>
+                        <Value>=[WOSchedule.NextWODate]</Value>
+                    </TextBox>
+                </Items>
+            </Detail>
+            <PageFooter Name="pageFooterSection1">
+                <Height>0.21164cm</Height>
+            </PageFooter>
+        </Sections>
+    </Report>
+</Report>

--- a/Package/CMMS/_project/REPORT_WO602000_RPX.xml
+++ b/Package/CMMS/_project/REPORT_WO602000_RPX.xml
@@ -1,0 +1,645 @@
+﻿<Report Name="wo602000.rpx">
+    <Report version="20211215" Name="report1">
+        <PageSettings>
+            <PaperKind>Letter</PaperKind>
+        </PageSettings>
+        <Relations>
+            <ReportRelation>
+                <ChildName>WOClass</ChildName>
+                <Links>
+                    <RelationRow>
+                        <ChildField>WOClassID</ChildField>
+                        <ParentField>WOClassID</ParentField>
+                    </RelationRow>
+                </Links>
+                <ParentName>WOOrder</ParentName>
+            </ReportRelation>
+            <ReportRelation>
+                <ChildName>WOEquipment</ChildName>
+                <Links>
+                    <RelationRow>
+                        <ChildField>EquipmentID</ChildField>
+                        <ParentField>EquipmentID</ParentField>
+                    </RelationRow>
+                </Links>
+                <ParentName>WOOrder</ParentName>
+            </ReportRelation>
+        </Relations>
+        <SchemaUrl>http://localhost/CMMS</SchemaUrl>
+        <Sorting>
+            <SortExp>
+                <DataField>WOOrder.WorkOrderType</DataField>
+            </SortExp>
+            <SortExp>
+                <DataField>WOOrder.WorkOrderCD</DataField>
+            </SortExp>
+        </Sorting>
+        <Tables>
+            <ReportTable Name="WOOrder">
+                <Fields>
+                    <ReportField Name="AMBATCOLOR_Attributes">
+                    </ReportField>
+                    <ReportField Name="AMBATLEN_Attributes">
+                    </ReportField>
+                    <ReportField Name="AMBATPT_Attributes">
+                    </ReportField>
+                    <ReportField Name="AMBATWGT_Attributes">
+                    </ReportField>
+                    <ReportField Name="Approved">
+                        <DataType>Boolean</DataType>
+                    </ReportField>
+                    <ReportField Name="BranchID">
+                        <DataType>Int32</DataType>
+                    </ReportField>
+                    <ReportField Name="ClassID">
+                    </ReportField>
+                    <ReportField Name="CreatedByID">
+                    </ReportField>
+                    <ReportField Name="CreatedByID_Creator_displayName">
+                    </ReportField>
+                    <ReportField Name="CreatedByID_Creator_Username">
+                    </ReportField>
+                    <ReportField Name="CreatedByID_description">
+                    </ReportField>
+                    <ReportField Name="CreatedByScreenID">
+                    </ReportField>
+                    <ReportField Name="CreatedDateTime">
+                        <DataType>DateTime</DataType>
+                    </ReportField>
+                    <ReportField Name="CreatedDateTime_Day">
+                    </ReportField>
+                    <ReportField Name="CreatedDateTime_Hour">
+                    </ReportField>
+                    <ReportField Name="CreatedDateTime_Month">
+                    </ReportField>
+                    <ReportField Name="CreatedDateTime_Quarter">
+                    </ReportField>
+                    <ReportField Name="Descr">
+                    </ReportField>
+                    <ReportField Name="EquipmentID">
+                    </ReportField>
+                    <ReportField Name="EquipmentID_description">
+                    </ReportField>
+                    <ReportField Name="EquipmentID_WOEquipment_descr">
+                    </ReportField>
+                    <ReportField Name="FSRESOL_Attributes">
+                    </ReportField>
+                    <ReportField Name="HANDS_Attributes">
+                    </ReportField>
+                    <ReportField Name="Hold">
+                        <DataType>Boolean</DataType>
+                    </ReportField>
+                    <ReportField Name="LastLineNbr">
+                        <DataType>Int32</DataType>
+                    </ReportField>
+                    <ReportField Name="LastModifiedByID">
+                    </ReportField>
+                    <ReportField Name="LastModifiedByID_description">
+                    </ReportField>
+                    <ReportField Name="LastModifiedByID_Modifier_displayName">
+                    </ReportField>
+                    <ReportField Name="LastModifiedByID_Modifier_Username">
+                    </ReportField>
+                    <ReportField Name="LastModifiedByScreenID">
+                    </ReportField>
+                    <ReportField Name="LastModifiedDateTime">
+                        <DataType>DateTime</DataType>
+                    </ReportField>
+                    <ReportField Name="LastModifiedDateTime_Day">
+                    </ReportField>
+                    <ReportField Name="LastModifiedDateTime_Hour">
+                    </ReportField>
+                    <ReportField Name="LastModifiedDateTime_Month">
+                    </ReportField>
+                    <ReportField Name="LastModifiedDateTime_Quarter">
+                    </ReportField>
+                    <ReportField Name="NoteActivity">
+                    </ReportField>
+                    <ReportField Name="NoteFiles">
+                    </ReportField>
+                    <ReportField Name="NoteID">
+                        <DataType>Object</DataType>
+                    </ReportField>
+                    <ReportField Name="NoteImages">
+                    </ReportField>
+                    <ReportField Name="NoteText">
+                    </ReportField>
+                    <ReportField Name="OrigWorkOrderID">
+                        <DataType>Int32</DataType>
+                    </ReportField>
+                    <ReportField Name="OwnerID">
+                        <DataType>Int32</DataType>
+                    </ReportField>
+                    <ReportField Name="OwnerID_description">
+                    </ReportField>
+                    <ReportField Name="OwnerID_Owner_displayName">
+                    </ReportField>
+                    <ReportField Name="Priority">
+                    </ReportField>
+                    <ReportField Name="Rejected">
+                        <DataType>Boolean</DataType>
+                    </ReportField>
+                    <ReportField Name="RequestApproval">
+                        <DataType>Boolean</DataType>
+                    </ReportField>
+                    <ReportField Name="RequestDate">
+                        <DataType>DateTime</DataType>
+                    </ReportField>
+                    <ReportField Name="RequestDate_Day">
+                    </ReportField>
+                    <ReportField Name="RequestDate_Hour">
+                    </ReportField>
+                    <ReportField Name="RequestDate_Month">
+                    </ReportField>
+                    <ReportField Name="RequestDate_Quarter">
+                    </ReportField>
+                    <ReportField Name="ScheduleDate">
+                        <DataType>DateTime</DataType>
+                    </ReportField>
+                    <ReportField Name="ScheduleDate_Day">
+                    </ReportField>
+                    <ReportField Name="ScheduleDate_Hour">
+                    </ReportField>
+                    <ReportField Name="ScheduleDate_Month">
+                    </ReportField>
+                    <ReportField Name="ScheduleDate_Quarter">
+                    </ReportField>
+                    <ReportField Name="Selected">
+                        <DataType>Boolean</DataType>
+                    </ReportField>
+                    <ReportField Name="Status">
+                    </ReportField>
+                    <ReportField Name="Tstamp">
+                    </ReportField>
+                    <ReportField Name="WOClassID">
+                    </ReportField>
+                    <ReportField Name="WorkgroupID">
+                    </ReportField>
+                    <ReportField Name="WorkOrderCD">
+                    </ReportField>
+                    <ReportField Name="WorkOrderID">
+                        <DataType>Int32</DataType>
+                    </ReportField>
+                    <ReportField Name="WorkOrderType">
+                    </ReportField>
+                </Fields>
+                <FullName>CMMSlite.WO.WOOrder</FullName>
+            </ReportTable>
+            <ReportTable Name="WOLine">
+                <Fields>
+                    <ReportField Name="CreatedByID">
+                    </ReportField>
+                    <ReportField Name="CreatedByID_Creator_displayName">
+                    </ReportField>
+                    <ReportField Name="CreatedByID_Creator_Username">
+                    </ReportField>
+                    <ReportField Name="CreatedByID_description">
+                    </ReportField>
+                    <ReportField Name="CreatedByScreenID">
+                    </ReportField>
+                    <ReportField Name="CreatedDateTime">
+                        <DataType>DateTime</DataType>
+                    </ReportField>
+                    <ReportField Name="CreatedDateTime_Day">
+                    </ReportField>
+                    <ReportField Name="CreatedDateTime_Hour">
+                    </ReportField>
+                    <ReportField Name="CreatedDateTime_Month">
+                    </ReportField>
+                    <ReportField Name="CreatedDateTime_Quarter">
+                    </ReportField>
+                    <ReportField Name="Descr">
+                    </ReportField>
+                    <ReportField Name="EquipmentID">
+                    </ReportField>
+                    <ReportField Name="LastFailureLineNbr">
+                        <DataType>Int32</DataType>
+                    </ReportField>
+                    <ReportField Name="LastItemLineNbr">
+                        <DataType>Int32</DataType>
+                    </ReportField>
+                    <ReportField Name="LastLaborLineNbr">
+                        <DataType>Int32</DataType>
+                    </ReportField>
+                    <ReportField Name="LastMeasureLineNbr">
+                        <DataType>Int32</DataType>
+                    </ReportField>
+                    <ReportField Name="LastModifiedByID">
+                    </ReportField>
+                    <ReportField Name="LastModifiedByID_description">
+                    </ReportField>
+                    <ReportField Name="LastModifiedByID_Modifier_displayName">
+                    </ReportField>
+                    <ReportField Name="LastModifiedByID_Modifier_Username">
+                    </ReportField>
+                    <ReportField Name="LastModifiedByScreenID">
+                    </ReportField>
+                    <ReportField Name="LastModifiedDateTime">
+                        <DataType>DateTime</DataType>
+                    </ReportField>
+                    <ReportField Name="LastModifiedDateTime_Day">
+                    </ReportField>
+                    <ReportField Name="LastModifiedDateTime_Hour">
+                    </ReportField>
+                    <ReportField Name="LastModifiedDateTime_Month">
+                    </ReportField>
+                    <ReportField Name="LastModifiedDateTime_Quarter">
+                    </ReportField>
+                    <ReportField Name="LastToolLineNbr">
+                        <DataType>Int32</DataType>
+                    </ReportField>
+                    <ReportField Name="LineNbr">
+                        <DataType>Int32</DataType>
+                    </ReportField>
+                    <ReportField Name="NoteActivity">
+                    </ReportField>
+                    <ReportField Name="NoteFiles">
+                    </ReportField>
+                    <ReportField Name="NoteID">
+                        <DataType>Object</DataType>
+                    </ReportField>
+                    <ReportField Name="NoteImages">
+                    </ReportField>
+                    <ReportField Name="NoteText">
+                    </ReportField>
+                    <ReportField Name="Tstamp">
+                    </ReportField>
+                    <ReportField Name="WorkOrderID">
+                        <DataType>Int32</DataType>
+                    </ReportField>
+                </Fields>
+                <FullName>CMMSlite.WO.WOLine</FullName>
+            </ReportTable>
+            <ReportTable Name="WOClass">
+                <Fields>
+                    <ReportField Name="CreatedByID">
+                    </ReportField>
+                    <ReportField Name="CreatedByID_Creator_displayName">
+                    </ReportField>
+                    <ReportField Name="CreatedByID_Creator_Username">
+                    </ReportField>
+                    <ReportField Name="CreatedByID_description">
+                    </ReportField>
+                    <ReportField Name="CreatedByScreenID">
+                    </ReportField>
+                    <ReportField Name="CreatedDateTime">
+                        <DataType>DateTime</DataType>
+                    </ReportField>
+                    <ReportField Name="CreatedDateTime_Day">
+                    </ReportField>
+                    <ReportField Name="CreatedDateTime_Hour">
+                    </ReportField>
+                    <ReportField Name="CreatedDateTime_Month">
+                    </ReportField>
+                    <ReportField Name="CreatedDateTime_Quarter">
+                    </ReportField>
+                    <ReportField Name="Descr">
+                    </ReportField>
+                    <ReportField Name="LastModifiedByID">
+                    </ReportField>
+                    <ReportField Name="LastModifiedByID_description">
+                    </ReportField>
+                    <ReportField Name="LastModifiedByID_Modifier_displayName">
+                    </ReportField>
+                    <ReportField Name="LastModifiedByID_Modifier_Username">
+                    </ReportField>
+                    <ReportField Name="LastModifiedByScreenID">
+                    </ReportField>
+                    <ReportField Name="LastModifiedDateTime">
+                        <DataType>DateTime</DataType>
+                    </ReportField>
+                    <ReportField Name="LastModifiedDateTime_Day">
+                    </ReportField>
+                    <ReportField Name="LastModifiedDateTime_Hour">
+                    </ReportField>
+                    <ReportField Name="LastModifiedDateTime_Month">
+                    </ReportField>
+                    <ReportField Name="LastModifiedDateTime_Quarter">
+                    </ReportField>
+                    <ReportField Name="NoteActivity">
+                    </ReportField>
+                    <ReportField Name="NoteFiles">
+                    </ReportField>
+                    <ReportField Name="NoteID">
+                        <DataType>Object</DataType>
+                    </ReportField>
+                    <ReportField Name="NoteImages">
+                    </ReportField>
+                    <ReportField Name="NoteText">
+                    </ReportField>
+                    <ReportField Name="Tstamp">
+                    </ReportField>
+                    <ReportField Name="WOClassID">
+                    </ReportField>
+                </Fields>
+                <FullName>CMMSlite.WO.WOClass</FullName>
+            </ReportTable>
+            <ReportTable Name="WOEquipment">
+                <Fields>
+                    <ReportField Name="AMMachID">
+                    </ReportField>
+                    <ReportField Name="AMMachID_AMMach_descr">
+                    </ReportField>
+                    <ReportField Name="AMMachID_description">
+                    </ReportField>
+                    <ReportField Name="AssetID">
+                    </ReportField>
+                    <ReportField Name="BranchID">
+                    </ReportField>
+                    <ReportField Name="BranchID_Branch_acctName">
+                    </ReportField>
+                    <ReportField Name="BranchID_description">
+                    </ReportField>
+                    <ReportField Name="BranchID_Segment1">
+                    </ReportField>
+                    <ReportField Name="CreatedByID">
+                    </ReportField>
+                    <ReportField Name="CreatedByID_Creator_displayName">
+                    </ReportField>
+                    <ReportField Name="CreatedByID_Creator_Username">
+                    </ReportField>
+                    <ReportField Name="CreatedByID_description">
+                    </ReportField>
+                    <ReportField Name="CreatedByScreenID">
+                    </ReportField>
+                    <ReportField Name="CreatedDateTime">
+                        <DataType>DateTime</DataType>
+                    </ReportField>
+                    <ReportField Name="CreatedDateTime_Day">
+                    </ReportField>
+                    <ReportField Name="CreatedDateTime_Hour">
+                    </ReportField>
+                    <ReportField Name="CreatedDateTime_Month">
+                    </ReportField>
+                    <ReportField Name="CreatedDateTime_Quarter">
+                    </ReportField>
+                    <ReportField Name="Criticality">
+                    </ReportField>
+                    <ReportField Name="DateInstalled">
+                        <DataType>DateTime</DataType>
+                    </ReportField>
+                    <ReportField Name="DateInstalled_Day">
+                    </ReportField>
+                    <ReportField Name="DateInstalled_Hour">
+                    </ReportField>
+                    <ReportField Name="DateInstalled_Month">
+                    </ReportField>
+                    <ReportField Name="DateInstalled_Quarter">
+                    </ReportField>
+                    <ReportField Name="DepartmentID">
+                    </ReportField>
+                    <ReportField Name="DepartmentID_description">
+                    </ReportField>
+                    <ReportField Name="DepartmentID_EPDepartment_description">
+                    </ReportField>
+                    <ReportField Name="Descr">
+                    </ReportField>
+                    <ReportField Name="EquipmentCD">
+                    </ReportField>
+                    <ReportField Name="EquipmentID">
+                        <DataType>Int32</DataType>
+                    </ReportField>
+                    <ReportField Name="EquipmentType">
+                    </ReportField>
+                    <ReportField Name="InventoryID">
+                    </ReportField>
+                    <ReportField Name="InventoryID_description">
+                    </ReportField>
+                    <ReportField Name="InventoryID_InventoryItem_descr">
+                    </ReportField>
+                    <ReportField Name="InventoryID_Segment1">
+                    </ReportField>
+                    <ReportField Name="LastModifiedByID">
+                    </ReportField>
+                    <ReportField Name="LastModifiedByID_description">
+                    </ReportField>
+                    <ReportField Name="LastModifiedByID_Modifier_displayName">
+                    </ReportField>
+                    <ReportField Name="LastModifiedByID_Modifier_Username">
+                    </ReportField>
+                    <ReportField Name="LastModifiedByScreenID">
+                    </ReportField>
+                    <ReportField Name="LastModifiedDateTime">
+                        <DataType>DateTime</DataType>
+                    </ReportField>
+                    <ReportField Name="LastModifiedDateTime_Day">
+                    </ReportField>
+                    <ReportField Name="LastModifiedDateTime_Hour">
+                    </ReportField>
+                    <ReportField Name="LastModifiedDateTime_Month">
+                    </ReportField>
+                    <ReportField Name="LastModifiedDateTime_Quarter">
+                    </ReportField>
+                    <ReportField Name="NoteActivity">
+                    </ReportField>
+                    <ReportField Name="NoteFiles">
+                    </ReportField>
+                    <ReportField Name="NoteID">
+                        <DataType>Object</DataType>
+                    </ReportField>
+                    <ReportField Name="NoteImages">
+                    </ReportField>
+                    <ReportField Name="NoteText">
+                    </ReportField>
+                    <ReportField Name="PhysicalLocation">
+                    </ReportField>
+                    <ReportField Name="SerialNbr">
+                    </ReportField>
+                    <ReportField Name="SMEquipmentID">
+                    </ReportField>
+                    <ReportField Name="SMEquipmentID_description">
+                    </ReportField>
+                    <ReportField Name="SMEquipmentID_FSEquipment_descr">
+                    </ReportField>
+                    <ReportField Name="Status">
+                    </ReportField>
+                    <ReportField Name="Tstamp">
+                    </ReportField>
+                </Fields>
+                <FullName>CMMSlite.WO.WOEquipment</FullName>
+            </ReportTable>
+        </Tables>
+        <Version>20211215</Version>
+        <ViewerFields>
+            <ViewerField Name="WOOrder.WorkOrderType">
+            </ViewerField>
+            <ViewerField Name="WOOrder.WorkOrderCD">
+            </ViewerField>
+        </ViewerFields>
+        <Sections>
+            <PageHeader Name="pageHeaderSection1">
+                <Height>2.1164cm</Height>
+                <Items>
+                    <Panel Name="panel1">
+                        <Location>0px, 56px</Location>
+                        <Size>720px, 24px</Size>
+                        <Style>
+                            <BackColor>AliceBlue</BackColor>
+                            <BorderStyle>
+                                <Bottom>Solid</Bottom>
+                                <Top>Solid</Top>
+                            </BorderStyle>
+                        </Style>
+                        <Items>
+                            <TextBox Name="textBox3">
+                                <Location>0px, 0px</Location>
+                                <Size>120px, 24px</Size>
+                                <Style>
+                                    <Font>
+                                        <Style>Bold</Style>
+                                    </Font>
+                                    <VerticalAlign>Middle</VerticalAlign>
+                                </Style>
+                                <Value>Type</Value>
+                            </TextBox>
+                            <TextBox Name="textBox4">
+                                <Location>128px, 0px</Location>
+                                <Size>120px, 24px</Size>
+                                <Style>
+                                    <Font>
+                                        <Style>Bold</Style>
+                                    </Font>
+                                    <VerticalAlign>Middle</VerticalAlign>
+                                </Style>
+                                <Value>Work Order ID</Value>
+                            </TextBox>
+                            <TextBox Name="textBox5">
+                                <Location>424px, 0px</Location>
+                                <Size>120px, 24px</Size>
+                                <Style>
+                                    <Font>
+                                        <Style>Bold</Style>
+                                    </Font>
+                                    <VerticalAlign>Middle</VerticalAlign>
+                                </Style>
+                                <Value>Class ID</Value>
+                            </TextBox>
+                            <TextBox Name="textBox9">
+                                <Location>544px, 0px</Location>
+                                <Size>160px, 24px</Size>
+                                <Style>
+                                    <Font>
+                                        <Style>Bold</Style>
+                                    </Font>
+                                    <VerticalAlign>Middle</VerticalAlign>
+                                </Style>
+                                <Value>Equipment ID</Value>
+                            </TextBox>
+                        </Items>
+                    </Panel>
+                    <TextBox Name="textBox18">
+                        <Location>0px, 0px</Location>
+                        <Size>312px, 16px</Size>
+                        <Style>
+                            <Font>
+                                <Style>Bold</Style>
+                            </Font>
+                        </Style>
+                        <Value>CMMS WORK ORDER DETAILS</Value>
+                    </TextBox>
+                    <TextBox Name="textBox19">
+                        <Location>640px, 0px</Location>
+                        <Size>80px, 24px</Size>
+                        <Style>
+                            <TextAlign>Right</TextAlign>
+                        </Style>
+                        <Value>=[PageOf]</Value>
+                    </TextBox>
+                    <TextBox Name="textBox20">
+                        <Location>568px, 0px</Location>
+                        <Size>64px, 24px</Size>
+                        <Style>
+                            <Font>
+                                <Style>Bold</Style>
+                            </Font>
+                        </Style>
+                        <Value>Page:</Value>
+                    </TextBox>
+                    <TextBox Name="textBox21">
+                        <Location>568px, 24px</Location>
+                        <Size>64px, 24px</Size>
+                        <Style>
+                            <Font>
+                                <Style>Bold</Style>
+                            </Font>
+                        </Style>
+                        <Value>Date:</Value>
+                    </TextBox>
+                    <TextBox Name="textBox22">
+                        <Location>640px, 24px</Location>
+                        <Size>80px, 24px</Size>
+                        <Style>
+                            <TextAlign>Right</TextAlign>
+                        </Style>
+                        <Value>=[@Today]</Value>
+                    </TextBox>
+                    <TextBox Name="textBox23">
+                        <Location>0px, 24px</Location>
+                        <Size>40px, 24px</Size>
+                        <Style>
+                            <Font>
+                                <Style>Bold</Style>
+                            </Font>
+                        </Style>
+                        <Value>User:</Value>
+                    </TextBox>
+                    <TextBox Name="textBox24">
+                        <Location>48px, 24px</Location>
+                        <Size>176px, 24px</Size>
+                        <Value>=Report.GetDefUI('AccessInfo.DisplayName')</Value>
+                        <WrapText>False</WrapText>
+                    </TextBox>
+                </Items>
+            </PageHeader>
+            <Detail Name="detailSection1">
+                <Height>2.96296cm</Height>
+                <Items>
+                    <Line Name="line1">
+                        <Location>0px, 96px</Location>
+                        <Size>696px, 8px</Size>
+                    </Line>
+                    <SubReport Name="subReport1">
+                        <Location>16px, 56px</Location>
+                        <Parameters>
+                            <ExternalParameter>
+                                <Name>WorkOrderID</Name>
+                                <Type>Integer</Type>
+                                <ValueExpr>=[WOOrder.WorkOrderID]</ValueExpr>
+                            </ExternalParameter>
+                        </Parameters>
+                        <ReportName>wo602001.rpx</ReportName>
+                        <Size>696px, 24px</Size>
+                    </SubReport>
+                    <TextBox Name="textBox1">
+                        <Location>128px, 0px</Location>
+                        <Size>120px, 24px</Size>
+                        <Value>=[WOOrder.WorkOrderCD]</Value>
+                    </TextBox>
+                    <TextBox Name="textBox2">
+                        <Location>0px, 0px</Location>
+                        <Size>120px, 24px</Size>
+                        <Value>=[WOOrder.WorkOrderType]</Value>
+                    </TextBox>
+                    <TextBox Name="textBox6">
+                        <Location>552px, 0px</Location>
+                        <Size>160px, 24px</Size>
+                        <Value>=[WOEquipment.EquipmentCD]</Value>
+                    </TextBox>
+                    <TextBox Name="textBox7">
+                        <Location>424px, 0px</Location>
+                        <Size>120px, 24px</Size>
+                        <Value>=[WOClass.WOClassID]</Value>
+                    </TextBox>
+                    <TextBox Name="textBox8">
+                        <Location>16px, 24px</Location>
+                        <Size>696px, 24px</Size>
+                        <Value>=[WOOrder.Descr]</Value>
+                    </TextBox>
+                </Items>
+            </Detail>
+            <PageFooter Name="pageFooterSection1">
+                <Expanded>False</Expanded>
+            </PageFooter>
+        </Sections>
+    </Report>
+</Report>

--- a/Package/CMMS/_project/REPORT_WO602001_RPX.xml
+++ b/Package/CMMS/_project/REPORT_WO602001_RPX.xml
@@ -1,0 +1,398 @@
+﻿<Report Name="wo602001.rpx">
+    <Report version="20211215" Name="report1">
+        <Filters>
+            <FilterExp>
+                <DataField>WOLine.WorkOrderID</DataField>
+                <Value>@WorkOrderID</Value>
+            </FilterExp>
+        </Filters>
+        <Parameters>
+            <ReportParameter>
+                <Name>WorkOrderID</Name>
+            </ReportParameter>
+        </Parameters>
+        <Relations>
+            <ReportRelation>
+                <ChildName>WOEquipment</ChildName>
+                <Links>
+                    <RelationRow>
+                        <ChildField>EquipmentID</ChildField>
+                        <ParentField>EquipmentID</ParentField>
+                    </RelationRow>
+                </Links>
+                <ParentName>WOLine</ParentName>
+            </ReportRelation>
+        </Relations>
+        <SchemaUrl>http://localhost/CMMS</SchemaUrl>
+        <Tables>
+            <ReportTable Name="WOLine">
+                <Fields>
+                    <ReportField Name="CreatedByID">
+                    </ReportField>
+                    <ReportField Name="CreatedByID_Creator_displayName">
+                    </ReportField>
+                    <ReportField Name="CreatedByID_Creator_Username">
+                    </ReportField>
+                    <ReportField Name="CreatedByID_description">
+                    </ReportField>
+                    <ReportField Name="CreatedByScreenID">
+                    </ReportField>
+                    <ReportField Name="CreatedDateTime">
+                        <DataType>DateTime</DataType>
+                    </ReportField>
+                    <ReportField Name="CreatedDateTime_Day">
+                    </ReportField>
+                    <ReportField Name="CreatedDateTime_Hour">
+                    </ReportField>
+                    <ReportField Name="CreatedDateTime_Month">
+                    </ReportField>
+                    <ReportField Name="CreatedDateTime_Quarter">
+                    </ReportField>
+                    <ReportField Name="Descr">
+                    </ReportField>
+                    <ReportField Name="EquipmentID">
+                    </ReportField>
+                    <ReportField Name="LastFailureLineNbr">
+                        <DataType>Int32</DataType>
+                    </ReportField>
+                    <ReportField Name="LastItemLineNbr">
+                        <DataType>Int32</DataType>
+                    </ReportField>
+                    <ReportField Name="LastLaborLineNbr">
+                        <DataType>Int32</DataType>
+                    </ReportField>
+                    <ReportField Name="LastMeasureLineNbr">
+                        <DataType>Int32</DataType>
+                    </ReportField>
+                    <ReportField Name="LastModifiedByID">
+                    </ReportField>
+                    <ReportField Name="LastModifiedByID_description">
+                    </ReportField>
+                    <ReportField Name="LastModifiedByID_Modifier_displayName">
+                    </ReportField>
+                    <ReportField Name="LastModifiedByID_Modifier_Username">
+                    </ReportField>
+                    <ReportField Name="LastModifiedByScreenID">
+                    </ReportField>
+                    <ReportField Name="LastModifiedDateTime">
+                        <DataType>DateTime</DataType>
+                    </ReportField>
+                    <ReportField Name="LastModifiedDateTime_Day">
+                    </ReportField>
+                    <ReportField Name="LastModifiedDateTime_Hour">
+                    </ReportField>
+                    <ReportField Name="LastModifiedDateTime_Month">
+                    </ReportField>
+                    <ReportField Name="LastModifiedDateTime_Quarter">
+                    </ReportField>
+                    <ReportField Name="LastToolLineNbr">
+                        <DataType>Int32</DataType>
+                    </ReportField>
+                    <ReportField Name="LineNbr">
+                        <DataType>Int32</DataType>
+                    </ReportField>
+                    <ReportField Name="NoteActivity">
+                    </ReportField>
+                    <ReportField Name="NoteFiles">
+                    </ReportField>
+                    <ReportField Name="NoteID">
+                        <DataType>Object</DataType>
+                    </ReportField>
+                    <ReportField Name="NoteImages">
+                    </ReportField>
+                    <ReportField Name="NoteText">
+                    </ReportField>
+                    <ReportField Name="Tstamp">
+                    </ReportField>
+                    <ReportField Name="WorkOrderID">
+                        <DataType>Int32</DataType>
+                    </ReportField>
+                </Fields>
+                <FullName>CMMSlite.WO.WOLine</FullName>
+            </ReportTable>
+            <ReportTable Name="WOEquipment">
+                <Fields>
+                    <ReportField Name="AMMachID">
+                    </ReportField>
+                    <ReportField Name="AMMachID_AMMach_descr">
+                    </ReportField>
+                    <ReportField Name="AMMachID_description">
+                    </ReportField>
+                    <ReportField Name="AssetID">
+                    </ReportField>
+                    <ReportField Name="BranchID">
+                    </ReportField>
+                    <ReportField Name="BranchID_Branch_acctName">
+                    </ReportField>
+                    <ReportField Name="BranchID_description">
+                    </ReportField>
+                    <ReportField Name="BranchID_Segment1">
+                    </ReportField>
+                    <ReportField Name="CreatedByID">
+                    </ReportField>
+                    <ReportField Name="CreatedByID_Creator_displayName">
+                    </ReportField>
+                    <ReportField Name="CreatedByID_Creator_Username">
+                    </ReportField>
+                    <ReportField Name="CreatedByID_description">
+                    </ReportField>
+                    <ReportField Name="CreatedByScreenID">
+                    </ReportField>
+                    <ReportField Name="CreatedDateTime">
+                        <DataType>DateTime</DataType>
+                    </ReportField>
+                    <ReportField Name="CreatedDateTime_Day">
+                    </ReportField>
+                    <ReportField Name="CreatedDateTime_Hour">
+                    </ReportField>
+                    <ReportField Name="CreatedDateTime_Month">
+                    </ReportField>
+                    <ReportField Name="CreatedDateTime_Quarter">
+                    </ReportField>
+                    <ReportField Name="Criticality">
+                    </ReportField>
+                    <ReportField Name="DateInstalled">
+                        <DataType>DateTime</DataType>
+                    </ReportField>
+                    <ReportField Name="DateInstalled_Day">
+                    </ReportField>
+                    <ReportField Name="DateInstalled_Hour">
+                    </ReportField>
+                    <ReportField Name="DateInstalled_Month">
+                    </ReportField>
+                    <ReportField Name="DateInstalled_Quarter">
+                    </ReportField>
+                    <ReportField Name="DepartmentID">
+                    </ReportField>
+                    <ReportField Name="DepartmentID_description">
+                    </ReportField>
+                    <ReportField Name="DepartmentID_EPDepartment_description">
+                    </ReportField>
+                    <ReportField Name="Descr">
+                    </ReportField>
+                    <ReportField Name="EquipmentCD">
+                    </ReportField>
+                    <ReportField Name="EquipmentID">
+                        <DataType>Int32</DataType>
+                    </ReportField>
+                    <ReportField Name="EquipmentType">
+                    </ReportField>
+                    <ReportField Name="InventoryID">
+                    </ReportField>
+                    <ReportField Name="InventoryID_description">
+                    </ReportField>
+                    <ReportField Name="InventoryID_InventoryItem_descr">
+                    </ReportField>
+                    <ReportField Name="InventoryID_Segment1">
+                    </ReportField>
+                    <ReportField Name="LastModifiedByID">
+                    </ReportField>
+                    <ReportField Name="LastModifiedByID_description">
+                    </ReportField>
+                    <ReportField Name="LastModifiedByID_Modifier_displayName">
+                    </ReportField>
+                    <ReportField Name="LastModifiedByID_Modifier_Username">
+                    </ReportField>
+                    <ReportField Name="LastModifiedByScreenID">
+                    </ReportField>
+                    <ReportField Name="LastModifiedDateTime">
+                        <DataType>DateTime</DataType>
+                    </ReportField>
+                    <ReportField Name="LastModifiedDateTime_Day">
+                    </ReportField>
+                    <ReportField Name="LastModifiedDateTime_Hour">
+                    </ReportField>
+                    <ReportField Name="LastModifiedDateTime_Month">
+                    </ReportField>
+                    <ReportField Name="LastModifiedDateTime_Quarter">
+                    </ReportField>
+                    <ReportField Name="NoteActivity">
+                    </ReportField>
+                    <ReportField Name="NoteFiles">
+                    </ReportField>
+                    <ReportField Name="NoteID">
+                        <DataType>Object</DataType>
+                    </ReportField>
+                    <ReportField Name="NoteImages">
+                    </ReportField>
+                    <ReportField Name="NoteText">
+                    </ReportField>
+                    <ReportField Name="PhysicalLocation">
+                    </ReportField>
+                    <ReportField Name="SerialNbr">
+                    </ReportField>
+                    <ReportField Name="SMEquipmentID">
+                    </ReportField>
+                    <ReportField Name="SMEquipmentID_description">
+                    </ReportField>
+                    <ReportField Name="SMEquipmentID_FSEquipment_descr">
+                    </ReportField>
+                    <ReportField Name="Status">
+                    </ReportField>
+                    <ReportField Name="Tstamp">
+                    </ReportField>
+                </Fields>
+                <FullName>CMMSlite.WO.WOEquipment</FullName>
+            </ReportTable>
+        </Tables>
+        <Version>20211215</Version>
+        <Sections>
+            <PageHeader Name="pageHeaderSection1">
+                <Height>0.21164cm</Height>
+            </PageHeader>
+            <Detail Name="detailSection1">
+                <Height>7.40741cm</Height>
+                <Items>
+                    <Line Name="line1">
+                        <LineStyle>Dashed</LineStyle>
+                        <Location>0px, 270px</Location>
+                        <Size>696px, 8px</Size>
+                    </Line>
+                    <SubReport Name="subReport1">
+                        <Location>24px, 48px</Location>
+                        <Parameters>
+                            <ExternalParameter>
+                                <Name>WorkOrderID</Name>
+                                <ValueExpr>=[WOLine.WorkOrderID]</ValueExpr>
+                            </ExternalParameter>
+                            <ExternalParameter>
+                                <Name>LineNbr</Name>
+                                <ValueExpr>=[WOLine.LineNbr]</ValueExpr>
+                            </ExternalParameter>
+                        </Parameters>
+                        <ReportName>wo602002.rpx</ReportName>
+                        <Size>648px, 24px</Size>
+                    </SubReport>
+                    <SubReport Name="subReport2">
+                        <Location>24px, 96px</Location>
+                        <Parameters>
+                            <ExternalParameter>
+                                <Name>WorkOrderID</Name>
+                                <ValueExpr>=[WOLine.WorkOrderID]</ValueExpr>
+                            </ExternalParameter>
+                            <ExternalParameter>
+                                <Name>LineNbr</Name>
+                                <ValueExpr>=[WOLine.LineNbr]</ValueExpr>
+                            </ExternalParameter>
+                        </Parameters>
+                        <ReportName>wo602003.rpx</ReportName>
+                        <Size>648px, 24px</Size>
+                    </SubReport>
+                    <SubReport Name="subReport3">
+                        <Location>24px, 144px</Location>
+                        <Parameters>
+                            <ExternalParameter>
+                                <Name>WorkOrderID</Name>
+                                <ValueExpr>=[WOLine.WorkOrderID]</ValueExpr>
+                            </ExternalParameter>
+                            <ExternalParameter>
+                                <Name>LineNbr</Name>
+                                <ValueExpr>=[WOLine.LineNbr]</ValueExpr>
+                            </ExternalParameter>
+                        </Parameters>
+                        <ReportName>wo602004.rpx</ReportName>
+                        <Size>648px, 24px</Size>
+                    </SubReport>
+                    <SubReport Name="subReport4">
+                        <Location>24px, 192px</Location>
+                        <Parameters>
+                            <ExternalParameter>
+                                <Name>WorkOrderID</Name>
+                                <ValueExpr>=[WOLine.WorkOrderID]</ValueExpr>
+                            </ExternalParameter>
+                            <ExternalParameter>
+                                <Name>LineNbr</Name>
+                                <ValueExpr>=[WOLine.LineNbr]</ValueExpr>
+                            </ExternalParameter>
+                        </Parameters>
+                        <ReportName>wo602005.rpx</ReportName>
+                        <Size>648px, 24px</Size>
+                    </SubReport>
+                    <SubReport Name="subReport5">
+                        <Location>24px, 240px</Location>
+                        <Parameters>
+                            <ExternalParameter>
+                                <Name>WorkOrderID</Name>
+                                <ValueExpr>=[WOLine.WorkOrderID]</ValueExpr>
+                            </ExternalParameter>
+                            <ExternalParameter>
+                                <Name>LineNbr</Name>
+                                <ValueExpr>=[WOLine.LineNbr]</ValueExpr>
+                            </ExternalParameter>
+                        </Parameters>
+                        <ReportName>wo602006.rpx</ReportName>
+                        <Size>648px, 24px</Size>
+                    </SubReport>
+                    <TextBox Name="textBox1">
+                        <Location>0px, 0px</Location>
+                        <Size>40px, 24px</Size>
+                        <Value>=[WOLine.LineNbr]</Value>
+                    </TextBox>
+                    <TextBox Name="textBox2">
+                        <Location>48px, 0px</Location>
+                        <Size>512px, 24px</Size>
+                        <Value>=[WOLine.Descr]</Value>
+                    </TextBox>
+                    <TextBox Name="textBox3">
+                        <Location>568px, 0px</Location>
+                        <Size>120px, 24px</Size>
+                        <Value>=[WOEquipment.EquipmentCD]</Value>
+                    </TextBox>
+                    <TextBox Name="textBox4">
+                        <Location>24px, 32px</Location>
+                        <Size>120px, 16px</Size>
+                        <Style>
+                            <Font>
+                                <Style>Bold</Style>
+                            </Font>
+                        </Style>
+                        <Value>Labor</Value>
+                    </TextBox>
+                    <TextBox Name="textBox5">
+                        <Location>24px, 80px</Location>
+                        <Size>120px, 16px</Size>
+                        <Style>
+                            <Font>
+                                <Style>Bold</Style>
+                            </Font>
+                        </Style>
+                        <Value>Materials</Value>
+                    </TextBox>
+                    <TextBox Name="textBox6">
+                        <Location>24px, 128px</Location>
+                        <Size>120px, 16px</Size>
+                        <Style>
+                            <Font>
+                                <Style>Bold</Style>
+                            </Font>
+                        </Style>
+                        <Value>Tools</Value>
+                    </TextBox>
+                    <TextBox Name="textBox7">
+                        <Location>24px, 176px</Location>
+                        <Size>120px, 16px</Size>
+                        <Style>
+                            <Font>
+                                <Style>Bold</Style>
+                            </Font>
+                        </Style>
+                        <Value>Measurements</Value>
+                    </TextBox>
+                    <TextBox Name="textBox8">
+                        <Location>24px, 224px</Location>
+                        <Size>120px, 16px</Size>
+                        <Style>
+                            <Font>
+                                <Style>Bold</Style>
+                            </Font>
+                        </Style>
+                        <Value>Failure Modes</Value>
+                    </TextBox>
+                </Items>
+            </Detail>
+            <PageFooter Name="pageFooterSection1">
+                <Height>0.21164cm</Height>
+            </PageFooter>
+        </Sections>
+    </Report>
+</Report>

--- a/Package/CMMS/_project/REPORT_WO602002_RPX.xml
+++ b/Package/CMMS/_project/REPORT_WO602002_RPX.xml
@@ -1,0 +1,123 @@
+﻿<Report Name="wo602002.rpx">
+    <Report version="20211215" Name="report1">
+        <Filters>
+            <FilterExp>
+                <DataField>WOLineLabor.WorkOrderID</DataField>
+                <Value>@WorkOrderID</Value>
+            </FilterExp>
+            <FilterExp>
+                <DataField>WOLineLabor.WOLineNbr</DataField>
+                <Value>@LineNbr</Value>
+            </FilterExp>
+        </Filters>
+        <Parameters>
+            <ReportParameter>
+                <Name>WorkOrderID</Name>
+            </ReportParameter>
+            <ReportParameter>
+                <Name>LineNbr</Name>
+            </ReportParameter>
+        </Parameters>
+        <SchemaUrl>http://localhost/CMMS</SchemaUrl>
+        <Tables>
+            <ReportTable Name="WOLineLabor">
+                <Fields>
+                    <ReportField Name="CreatedByID">
+                    </ReportField>
+                    <ReportField Name="CreatedByID_Creator_displayName">
+                    </ReportField>
+                    <ReportField Name="CreatedByID_Creator_Username">
+                    </ReportField>
+                    <ReportField Name="CreatedByID_description">
+                    </ReportField>
+                    <ReportField Name="CreatedByScreenID">
+                    </ReportField>
+                    <ReportField Name="CreatedDateTime">
+                        <DataType>DateTime</DataType>
+                    </ReportField>
+                    <ReportField Name="CreatedDateTime_Day">
+                    </ReportField>
+                    <ReportField Name="CreatedDateTime_Hour">
+                    </ReportField>
+                    <ReportField Name="CreatedDateTime_Month">
+                    </ReportField>
+                    <ReportField Name="CreatedDateTime_Quarter">
+                    </ReportField>
+                    <ReportField Name="LaborHours">
+                        <DataType>Decimal</DataType>
+                    </ReportField>
+                    <ReportField Name="LaborType">
+                    </ReportField>
+                    <ReportField Name="LastModifiedByID">
+                    </ReportField>
+                    <ReportField Name="LastModifiedByID_description">
+                    </ReportField>
+                    <ReportField Name="LastModifiedByID_Modifier_displayName">
+                    </ReportField>
+                    <ReportField Name="LastModifiedByID_Modifier_Username">
+                    </ReportField>
+                    <ReportField Name="LastModifiedByScreenID">
+                    </ReportField>
+                    <ReportField Name="LastModifiedDateTime">
+                        <DataType>DateTime</DataType>
+                    </ReportField>
+                    <ReportField Name="LastModifiedDateTime_Day">
+                    </ReportField>
+                    <ReportField Name="LastModifiedDateTime_Hour">
+                    </ReportField>
+                    <ReportField Name="LastModifiedDateTime_Month">
+                    </ReportField>
+                    <ReportField Name="LastModifiedDateTime_Quarter">
+                    </ReportField>
+                    <ReportField Name="LineNbr">
+                        <DataType>Int32</DataType>
+                    </ReportField>
+                    <ReportField Name="NoteActivity">
+                    </ReportField>
+                    <ReportField Name="NoteFiles">
+                    </ReportField>
+                    <ReportField Name="NoteID">
+                        <DataType>Object</DataType>
+                    </ReportField>
+                    <ReportField Name="NoteImages">
+                    </ReportField>
+                    <ReportField Name="NoteText">
+                    </ReportField>
+                    <ReportField Name="Tstamp">
+                    </ReportField>
+                    <ReportField Name="WOLineNbr">
+                        <DataType>Int32</DataType>
+                    </ReportField>
+                    <ReportField Name="WorkOrderID">
+                        <DataType>Int32</DataType>
+                    </ReportField>
+                </Fields>
+                <FullName>CMMSlite.WO.WOLineLabor</FullName>
+            </ReportTable>
+        </Tables>
+        <Version>20211215</Version>
+        <Sections>
+            <PageHeader Name="pageHeaderSection1">
+                <Height>0.21164cm</Height>
+            </PageHeader>
+            <Detail Name="detailSection1">
+                <Height>0.63492cm</Height>
+                <Items>
+                    <TextBox Name="textBox1">
+                        <Location>0px, 0px</Location>
+                        <Size>120px, 24px</Size>
+                        <Value>=[WOLineLabor.LaborType]</Value>
+                    </TextBox>
+                    <TextBox Name="textBox2">
+                        <Location>128px, 0px</Location>
+                        <Size>120px, 24px</Size>
+                        <Value>=[WOLineLabor.LaborHours]</Value>
+                    </TextBox>
+                </Items>
+            </Detail>
+            <PageFooter Name="pageFooterSection1">
+                <Height>0.21164cm</Height>
+            </PageFooter>
+        </Sections>
+    </Report>
+</Report>

--- a/Package/CMMS/_project/REPORT_WO602003_RPX.xml
+++ b/Package/CMMS/_project/REPORT_WO602003_RPX.xml
@@ -1,0 +1,984 @@
+﻿<Report Name="wo602003.rpx">
+    <Report version="20211215" Name="report1">
+        <Filters>
+            <FilterExp>
+                <DataField>WOLineItem.WorkOrderID</DataField>
+                <Value>@WorkOrderID</Value>
+            </FilterExp>
+            <FilterExp>
+                <DataField>WOLineItem.WOLineNbr</DataField>
+                <Value>@LineNbr</Value>
+            </FilterExp>
+        </Filters>
+        <Parameters>
+            <ReportParameter>
+                <Name>WorkOrderID</Name>
+            </ReportParameter>
+            <ReportParameter>
+                <Name>LineNbr</Name>
+            </ReportParameter>
+        </Parameters>
+        <Relations>
+            <ReportRelation>
+                <ChildName>InventoryItem</ChildName>
+                <Links>
+                    <RelationRow>
+                        <ChildField>InventoryID</ChildField>
+                        <ParentField>InventoryID</ParentField>
+                    </RelationRow>
+                </Links>
+                <ParentName>WOLineItem</ParentName>
+            </ReportRelation>
+        </Relations>
+        <SchemaUrl>http://localhost/CMMS</SchemaUrl>
+        <Tables>
+            <ReportTable Name="WOLineItem">
+                <Fields>
+                    <ReportField Name="BaseUnit">
+                    </ReportField>
+                    <ReportField Name="CreatedByID">
+                    </ReportField>
+                    <ReportField Name="CreatedByID_Creator_displayName">
+                    </ReportField>
+                    <ReportField Name="CreatedByID_Creator_Username">
+                    </ReportField>
+                    <ReportField Name="CreatedByID_description">
+                    </ReportField>
+                    <ReportField Name="CreatedByScreenID">
+                    </ReportField>
+                    <ReportField Name="CreatedDateTime">
+                        <DataType>DateTime</DataType>
+                    </ReportField>
+                    <ReportField Name="CreatedDateTime_Day">
+                    </ReportField>
+                    <ReportField Name="CreatedDateTime_Hour">
+                    </ReportField>
+                    <ReportField Name="CreatedDateTime_Month">
+                    </ReportField>
+                    <ReportField Name="CreatedDateTime_Quarter">
+                    </ReportField>
+                    <ReportField Name="InventoryID">
+                    </ReportField>
+                    <ReportField Name="InventoryID_description">
+                    </ReportField>
+                    <ReportField Name="InventoryID_InventoryItem_descr">
+                    </ReportField>
+                    <ReportField Name="InventoryID_Segment1">
+                    </ReportField>
+                    <ReportField Name="LastModifiedByID">
+                    </ReportField>
+                    <ReportField Name="LastModifiedByID_description">
+                    </ReportField>
+                    <ReportField Name="LastModifiedByID_Modifier_displayName">
+                    </ReportField>
+                    <ReportField Name="LastModifiedByID_Modifier_Username">
+                    </ReportField>
+                    <ReportField Name="LastModifiedByScreenID">
+                    </ReportField>
+                    <ReportField Name="LastModifiedDateTime">
+                        <DataType>DateTime</DataType>
+                    </ReportField>
+                    <ReportField Name="LastModifiedDateTime_Day">
+                    </ReportField>
+                    <ReportField Name="LastModifiedDateTime_Hour">
+                    </ReportField>
+                    <ReportField Name="LastModifiedDateTime_Month">
+                    </ReportField>
+                    <ReportField Name="LastModifiedDateTime_Quarter">
+                    </ReportField>
+                    <ReportField Name="LineNbr">
+                        <DataType>Int32</DataType>
+                    </ReportField>
+                    <ReportField Name="NoteActivity">
+                    </ReportField>
+                    <ReportField Name="NoteFiles">
+                    </ReportField>
+                    <ReportField Name="NoteID">
+                        <DataType>Object</DataType>
+                    </ReportField>
+                    <ReportField Name="NoteImages">
+                    </ReportField>
+                    <ReportField Name="NoteText">
+                    </ReportField>
+                    <ReportField Name="Quantity">
+                        <DataType>Decimal</DataType>
+                    </ReportField>
+                    <ReportField Name="Tstamp">
+                    </ReportField>
+                    <ReportField Name="WOLineNbr">
+                        <DataType>Int32</DataType>
+                    </ReportField>
+                    <ReportField Name="WorkOrderID">
+                        <DataType>Int32</DataType>
+                    </ReportField>
+                </Fields>
+                <FullName>CMMSlite.WO.WOLineItem</FullName>
+            </ReportTable>
+            <ReportTable Name="InventoryItem">
+                <Fields>
+                    <ReportField Name="ABCCodeID">
+                    </ReportField>
+                    <ReportField Name="ABCCodeID_description">
+                    </ReportField>
+                    <ReportField Name="ABCCodeID_INABCCode_descr">
+                    </ReportField>
+                    <ReportField Name="ABCCodeIsFixed">
+                        <DataType>Boolean</DataType>
+                    </ReportField>
+                    <ReportField Name="AccrueCost">
+                        <DataType>Boolean</DataType>
+                    </ReportField>
+                    <ReportField Name="AMBOMID">
+                    </ReportField>
+                    <ReportField Name="AMBOMID_AMBomItem_descr">
+                    </ReportField>
+                    <ReportField Name="AMBOMID_description">
+                    </ReportField>
+                    <ReportField Name="AMCheckSchdMatlAvailability">
+                        <DataType>Boolean</DataType>
+                    </ReportField>
+                    <ReportField Name="AMConfigurationID">
+                    </ReportField>
+                    <ReportField Name="AMConfigurationID_AMConfiguration_descr">
+                    </ReportField>
+                    <ReportField Name="AMConfigurationID_description">
+                    </ReportField>
+                    <ReportField Name="AMCTPItem">
+                        <DataType>Boolean</DataType>
+                    </ReportField>
+                    <ReportField Name="AMDefaultMarkFor">
+                        <DataType>Int32</DataType>
+                    </ReportField>
+                    <ReportField Name="AMGroupWindow">
+                        <DataType>Int32</DataType>
+                    </ReportField>
+                    <ReportField Name="AMGroupWindowOverride">
+                        <DataType>Boolean</DataType>
+                    </ReportField>
+                    <ReportField Name="AMLotSize">
+                        <DataType>Decimal</DataType>
+                    </ReportField>
+                    <ReportField Name="AMLowLevel">
+                        <DataType>Int32</DataType>
+                    </ReportField>
+                    <ReportField Name="AMMakeToOrderItem">
+                        <DataType>Boolean</DataType>
+                    </ReportField>
+                    <ReportField Name="AMMaxOrdQty">
+                        <DataType>Decimal</DataType>
+                    </ReportField>
+                    <ReportField Name="AMMFGLeadTime">
+                        <DataType>Int32</DataType>
+                    </ReportField>
+                    <ReportField Name="AMMinOrdQty">
+                        <DataType>Decimal</DataType>
+                    </ReportField>
+                    <ReportField Name="AMMinQty">
+                        <DataType>Decimal</DataType>
+                    </ReportField>
+                    <ReportField Name="AMMinQtyOverride">
+                        <DataType>Boolean</DataType>
+                    </ReportField>
+                    <ReportField Name="AMMRPItem">
+                        <DataType>Boolean</DataType>
+                    </ReportField>
+                    <ReportField Name="AMPlanningBOMID">
+                    </ReportField>
+                    <ReportField Name="AMPlanningBOMID_AMBomItem_descr">
+                    </ReportField>
+                    <ReportField Name="AMPlanningBOMID_description">
+                    </ReportField>
+                    <ReportField Name="AMQtyRoundUp">
+                        <DataType>Boolean</DataType>
+                    </ReportField>
+                    <ReportField Name="AMReplenishmentSource">
+                    </ReportField>
+                    <ReportField Name="AMReplenishmentSourceOverride">
+                        <DataType>Boolean</DataType>
+                    </ReportField>
+                    <ReportField Name="AMSafetyStock">
+                        <DataType>Decimal</DataType>
+                    </ReportField>
+                    <ReportField Name="AMSafetyStockOverride">
+                        <DataType>Boolean</DataType>
+                    </ReportField>
+                    <ReportField Name="AMScrapLocationID">
+                    </ReportField>
+                    <ReportField Name="AMScrapLocationID_description">
+                    </ReportField>
+                    <ReportField Name="AMScrapLocationID_INLocation_descr">
+                    </ReportField>
+                    <ReportField Name="AMScrapLocationID_Segment1">
+                    </ReportField>
+                    <ReportField Name="AMScrapSiteID">
+                    </ReportField>
+                    <ReportField Name="AMScrapSiteID_description">
+                    </ReportField>
+                    <ReportField Name="AMScrapSiteID_INSite_descr">
+                    </ReportField>
+                    <ReportField Name="AMScrapSiteID_Segment1">
+                    </ReportField>
+                    <ReportField Name="AMWIPAcctID">
+                    </ReportField>
+                    <ReportField Name="AMWIPAcctID_Account_description">
+                    </ReportField>
+                    <ReportField Name="AMWIPAcctID_description">
+                    </ReportField>
+                    <ReportField Name="AMWIPAcctID_Segment1">
+                    </ReportField>
+                    <ReportField Name="AMWIPSubID">
+                    </ReportField>
+                    <ReportField Name="AMWIPSubID_description">
+                    </ReportField>
+                    <ReportField Name="AMWIPSubID_Segment1">
+                    </ReportField>
+                    <ReportField Name="AMWIPSubID_Segment2">
+                    </ReportField>
+                    <ReportField Name="AMWIPSubID_Sub_description">
+                    </ReportField>
+                    <ReportField Name="AMWIPVarianceAcctID">
+                    </ReportField>
+                    <ReportField Name="AMWIPVarianceAcctID_Account_description">
+                    </ReportField>
+                    <ReportField Name="AMWIPVarianceAcctID_description">
+                    </ReportField>
+                    <ReportField Name="AMWIPVarianceAcctID_Segment1">
+                    </ReportField>
+                    <ReportField Name="AMWIPVarianceSubID">
+                    </ReportField>
+                    <ReportField Name="AMWIPVarianceSubID_description">
+                    </ReportField>
+                    <ReportField Name="AMWIPVarianceSubID_Segment1">
+                    </ReportField>
+                    <ReportField Name="AMWIPVarianceSubID_Segment2">
+                    </ReportField>
+                    <ReportField Name="AMWIPVarianceSubID_Sub_description">
+                    </ReportField>
+                    <ReportField Name="AttributeDescriptionGroupID">
+                        <DataType>Int32</DataType>
+                    </ReportField>
+                    <ReportField Name="Availability">
+                    </ReportField>
+                    <ReportField Name="BaseItemVolume">
+                        <DataType>Decimal</DataType>
+                    </ReportField>
+                    <ReportField Name="BaseItemWeight">
+                        <DataType>Decimal</DataType>
+                    </ReportField>
+                    <ReportField Name="BasePrice">
+                        <DataType>Decimal</DataType>
+                    </ReportField>
+                    <ReportField Name="BaseUnit">
+                    </ReportField>
+                    <ReportField Name="BaseVolume">
+                        <DataType>Decimal</DataType>
+                    </ReportField>
+                    <ReportField Name="BaseWeight">
+                        <DataType>Decimal</DataType>
+                    </ReportField>
+                    <ReportField Name="BenefitExpenseAcctID">
+                    </ReportField>
+                    <ReportField Name="BenefitExpenseAcctID_Account_description">
+                    </ReportField>
+                    <ReportField Name="BenefitExpenseAcctID_description">
+                    </ReportField>
+                    <ReportField Name="BenefitExpenseAcctID_Segment1">
+                    </ReportField>
+                    <ReportField Name="BenefitExpenseSubID">
+                    </ReportField>
+                    <ReportField Name="BenefitExpenseSubID_description">
+                    </ReportField>
+                    <ReportField Name="BenefitExpenseSubID_Segment1">
+                    </ReportField>
+                    <ReportField Name="BenefitExpenseSubID_Segment2">
+                    </ReportField>
+                    <ReportField Name="BenefitExpenseSubID_Sub_description">
+                    </ReportField>
+                    <ReportField Name="Body">
+                    </ReportField>
+                    <ReportField Name="ClassID">
+                        <DataType>Int32</DataType>
+                    </ReportField>
+                    <ReportField Name="COGSAcctID">
+                    </ReportField>
+                    <ReportField Name="COGSAcctID_Account_description">
+                    </ReportField>
+                    <ReportField Name="COGSAcctID_description">
+                    </ReportField>
+                    <ReportField Name="COGSAcctID_Segment1">
+                    </ReportField>
+                    <ReportField Name="COGSSubID">
+                    </ReportField>
+                    <ReportField Name="COGSSubID_description">
+                    </ReportField>
+                    <ReportField Name="COGSSubID_Segment1">
+                    </ReportField>
+                    <ReportField Name="COGSSubID_Segment2">
+                    </ReportField>
+                    <ReportField Name="COGSSubID_Sub_description">
+                    </ReportField>
+                    <ReportField Name="COLOR_Attributes">
+                    </ReportField>
+                    <ReportField Name="ColumnAttributeValue">
+                    </ReportField>
+                    <ReportField Name="Commisionable">
+                        <DataType>Boolean</DataType>
+                    </ReportField>
+                    <ReportField Name="CompletePOLine">
+                    </ReportField>
+                    <ReportField Name="CONFIGURAB_Attributes">
+                    </ReportField>
+                    <ReportField Name="CostBasis">
+                    </ReportField>
+                    <ReportField Name="CountryOfOrigin">
+                    </ReportField>
+                    <ReportField Name="CountryOfOrigin_Country_description">
+                    </ReportField>
+                    <ReportField Name="CountryOfOrigin_description">
+                    </ReportField>
+                    <ReportField Name="CreatedByID">
+                    </ReportField>
+                    <ReportField Name="CreatedByID_Creator_displayName">
+                    </ReportField>
+                    <ReportField Name="CreatedByID_Creator_Username">
+                    </ReportField>
+                    <ReportField Name="CreatedByID_description">
+                    </ReportField>
+                    <ReportField Name="CreatedByScreenID">
+                    </ReportField>
+                    <ReportField Name="CreatedDateTime">
+                        <DataType>DateTime</DataType>
+                    </ReportField>
+                    <ReportField Name="CreatedDateTime_Day">
+                    </ReportField>
+                    <ReportField Name="CreatedDateTime_Hour">
+                    </ReportField>
+                    <ReportField Name="CreatedDateTime_Month">
+                    </ReportField>
+                    <ReportField Name="CreatedDateTime_Quarter">
+                    </ReportField>
+                    <ReportField Name="CycleID">
+                    </ReportField>
+                    <ReportField Name="CycleID_description">
+                    </ReportField>
+                    <ReportField Name="CycleID_INPICycle_descr">
+                    </ReportField>
+                    <ReportField Name="DecimalBaseUnit">
+                        <DataType>Boolean</DataType>
+                    </ReportField>
+                    <ReportField Name="DecimalPurchaseUnit">
+                        <DataType>Boolean</DataType>
+                    </ReportField>
+                    <ReportField Name="DecimalSalesUnit">
+                        <DataType>Boolean</DataType>
+                    </ReportField>
+                    <ReportField Name="DefaultColumnMatrixAttributeID">
+                    </ReportField>
+                    <ReportField Name="DefaultColumnMatrixAttributeID_CSAttribute_description">
+                    </ReportField>
+                    <ReportField Name="DefaultColumnMatrixAttributeID_description">
+                    </ReportField>
+                    <ReportField Name="DefaultRowMatrixAttributeID">
+                    </ReportField>
+                    <ReportField Name="DefaultRowMatrixAttributeID_CSAttribute_description">
+                    </ReportField>
+                    <ReportField Name="DefaultRowMatrixAttributeID_description">
+                    </ReportField>
+                    <ReportField Name="DefaultSubItemID">
+                    </ReportField>
+                    <ReportField Name="DefaultSubItemID_Segment1">
+                    </ReportField>
+                    <ReportField Name="DefaultSubItemOnEntry">
+                        <DataType>Boolean</DataType>
+                    </ReportField>
+                    <ReportField Name="DefaultTerm">
+                        <DataType>Decimal</DataType>
+                    </ReportField>
+                    <ReportField Name="DefaultTermUOM">
+                    </ReportField>
+                    <ReportField Name="DeferralAcctID">
+                    </ReportField>
+                    <ReportField Name="DeferralAcctID_Account_description">
+                    </ReportField>
+                    <ReportField Name="DeferralAcctID_description">
+                    </ReportField>
+                    <ReportField Name="DeferralAcctID_Segment1">
+                    </ReportField>
+                    <ReportField Name="DeferralSubID">
+                    </ReportField>
+                    <ReportField Name="DeferralSubID_description">
+                    </ReportField>
+                    <ReportField Name="DeferralSubID_Segment1">
+                    </ReportField>
+                    <ReportField Name="DeferralSubID_Segment2">
+                    </ReportField>
+                    <ReportField Name="DeferralSubID_Sub_description">
+                    </ReportField>
+                    <ReportField Name="DeferredCode">
+                    </ReportField>
+                    <ReportField Name="Descr">
+                    </ReportField>
+                    <ReportField Name="DfltReceiptLocationID">
+                    </ReportField>
+                    <ReportField Name="DfltReceiptLocationID_description">
+                    </ReportField>
+                    <ReportField Name="DfltReceiptLocationID_INLocation_descr">
+                    </ReportField>
+                    <ReportField Name="DfltReceiptLocationID_Segment1">
+                    </ReportField>
+                    <ReportField Name="DfltShipLocationID">
+                    </ReportField>
+                    <ReportField Name="DfltShipLocationID_description">
+                    </ReportField>
+                    <ReportField Name="DfltShipLocationID_INLocation_descr">
+                    </ReportField>
+                    <ReportField Name="DfltShipLocationID_Segment1">
+                    </ReportField>
+                    <ReportField Name="DfltSiteID">
+                    </ReportField>
+                    <ReportField Name="DfltSiteID_description">
+                    </ReportField>
+                    <ReportField Name="DfltSiteID_INSite_descr">
+                    </ReportField>
+                    <ReportField Name="DfltSiteID_Segment1">
+                    </ReportField>
+                    <ReportField Name="DiscAcctID">
+                        <DataType>Int32</DataType>
+                    </ReportField>
+                    <ReportField Name="DiscSubID">
+                        <DataType>Int32</DataType>
+                    </ReportField>
+                    <ReportField Name="EarningsAcctID">
+                    </ReportField>
+                    <ReportField Name="EarningsAcctID_Account_description">
+                    </ReportField>
+                    <ReportField Name="EarningsAcctID_description">
+                    </ReportField>
+                    <ReportField Name="EarningsAcctID_Segment1">
+                    </ReportField>
+                    <ReportField Name="EarningsSubID">
+                    </ReportField>
+                    <ReportField Name="EarningsSubID_description">
+                    </ReportField>
+                    <ReportField Name="EarningsSubID_Segment1">
+                    </ReportField>
+                    <ReportField Name="EarningsSubID_Segment2">
+                    </ReportField>
+                    <ReportField Name="EarningsSubID_Sub_description">
+                    </ReportField>
+                    <ReportField Name="EntityTypeID">
+                        <DataType>Int32</DataType>
+                    </ReportField>
+                    <ReportField Name="ExpenseAccrualAcctID">
+                        <DataType>Int32</DataType>
+                    </ReportField>
+                    <ReportField Name="ExpenseAccrualSubID">
+                        <DataType>Int32</DataType>
+                    </ReportField>
+                    <ReportField Name="ExpenseAcctID">
+                        <DataType>Int32</DataType>
+                    </ReportField>
+                    <ReportField Name="ExpenseSubID">
+                        <DataType>Int32</DataType>
+                    </ReportField>
+                    <ReportField Name="ExportToExternal">
+                        <DataType>Boolean</DataType>
+                    </ReportField>
+                    <ReportField Name="GenerationRuleCntr">
+                        <DataType>Int32</DataType>
+                    </ReportField>
+                    <ReportField Name="GroupMask">
+                        <DataType>Object</DataType>
+                    </ReportField>
+                    <ReportField Name="HasChild">
+                        <DataType>Boolean</DataType>
+                    </ReportField>
+                    <ReportField Name="HSTariffCode">
+                    </ReportField>
+                    <ReportField Name="ImageUrl">
+                    </ReportField>
+                    <ReportField Name="Included">
+                        <DataType>Boolean</DataType>
+                    </ReportField>
+                    <ReportField Name="InventoryCD">
+                    </ReportField>
+                    <ReportField Name="InventoryCD_Segment1">
+                    </ReportField>
+                    <ReportField Name="InventoryID">
+                        <DataType>Int32</DataType>
+                    </ReportField>
+                    <ReportField Name="InvtAcctID">
+                    </ReportField>
+                    <ReportField Name="InvtAcctID_Account_description">
+                    </ReportField>
+                    <ReportField Name="InvtAcctID_description">
+                    </ReportField>
+                    <ReportField Name="InvtAcctID_Segment1">
+                    </ReportField>
+                    <ReportField Name="InvtSubID">
+                    </ReportField>
+                    <ReportField Name="InvtSubID_description">
+                    </ReportField>
+                    <ReportField Name="InvtSubID_Segment1">
+                    </ReportField>
+                    <ReportField Name="InvtSubID_Segment2">
+                    </ReportField>
+                    <ReportField Name="InvtSubID_Sub_description">
+                    </ReportField>
+                    <ReportField Name="IsSplitted">
+                        <DataType>Boolean</DataType>
+                    </ReportField>
+                    <ReportField Name="IsTemplate">
+                        <DataType>Boolean</DataType>
+                    </ReportField>
+                    <ReportField Name="ItemClassID">
+                    </ReportField>
+                    <ReportField Name="ItemClassID_description">
+                    </ReportField>
+                    <ReportField Name="ItemClassID_INItemClass_descr">
+                    </ReportField>
+                    <ReportField Name="ItemClassID_Segment1">
+                    </ReportField>
+                    <ReportField Name="ItemClassID_Segment2">
+                    </ReportField>
+                    <ReportField Name="ItemClassID_Segment3">
+                    </ReportField>
+                    <ReportField Name="ItemStatus">
+                    </ReportField>
+                    <ReportField Name="ItemType">
+                    </ReportField>
+                    <ReportField Name="KitItem">
+                        <DataType>Boolean</DataType>
+                    </ReportField>
+                    <ReportField Name="LastModifiedByID">
+                    </ReportField>
+                    <ReportField Name="LastModifiedByID_description">
+                    </ReportField>
+                    <ReportField Name="LastModifiedByID_Modifier_displayName">
+                    </ReportField>
+                    <ReportField Name="LastModifiedByID_Modifier_Username">
+                    </ReportField>
+                    <ReportField Name="LastModifiedByScreenID">
+                    </ReportField>
+                    <ReportField Name="LastModifiedDateTime">
+                        <DataType>DateTime</DataType>
+                    </ReportField>
+                    <ReportField Name="LastModifiedDateTime_Day">
+                    </ReportField>
+                    <ReportField Name="LastModifiedDateTime_Hour">
+                    </ReportField>
+                    <ReportField Name="LastModifiedDateTime_Month">
+                    </ReportField>
+                    <ReportField Name="LastModifiedDateTime_Quarter">
+                    </ReportField>
+                    <ReportField Name="LastSiteID">
+                        <DataType>Int32</DataType>
+                    </ReportField>
+                    <ReportField Name="LastStdCost">
+                        <DataType>Decimal</DataType>
+                    </ReportField>
+                    <ReportField Name="LCVarianceAcctID">
+                    </ReportField>
+                    <ReportField Name="LCVarianceAcctID_Account_description">
+                    </ReportField>
+                    <ReportField Name="LCVarianceAcctID_description">
+                    </ReportField>
+                    <ReportField Name="LCVarianceAcctID_Segment1">
+                    </ReportField>
+                    <ReportField Name="LCVarianceSubID">
+                    </ReportField>
+                    <ReportField Name="LCVarianceSubID_description">
+                    </ReportField>
+                    <ReportField Name="LCVarianceSubID_Segment1">
+                    </ReportField>
+                    <ReportField Name="LCVarianceSubID_Segment2">
+                    </ReportField>
+                    <ReportField Name="LCVarianceSubID_Sub_description">
+                    </ReportField>
+                    <ReportField Name="LotSerClassID">
+                    </ReportField>
+                    <ReportField Name="LotSerClassID_description">
+                    </ReportField>
+                    <ReportField Name="LotSerClassID_INLotSerClass_descr">
+                    </ReportField>
+                    <ReportField Name="MarkupPct">
+                        <DataType>Decimal</DataType>
+                    </ReportField>
+                    <ReportField Name="MinGrossProfitPct">
+                        <DataType>Decimal</DataType>
+                    </ReportField>
+                    <ReportField Name="MovementClassID">
+                    </ReportField>
+                    <ReportField Name="MovementClassID_description">
+                    </ReportField>
+                    <ReportField Name="MovementClassID_INMovementClass_descr">
+                    </ReportField>
+                    <ReportField Name="MovementClassIsFixed">
+                        <DataType>Boolean</DataType>
+                    </ReportField>
+                    <ReportField Name="NegQty">
+                        <DataType>Boolean</DataType>
+                    </ReportField>
+                    <ReportField Name="NonStockReceipt">
+                        <DataType>Boolean</DataType>
+                    </ReportField>
+                    <ReportField Name="NonStockReceiptAsService">
+                        <DataType>Boolean</DataType>
+                    </ReportField>
+                    <ReportField Name="NonStockShip">
+                        <DataType>Boolean</DataType>
+                    </ReportField>
+                    <ReportField Name="NotAvailMode">
+                    </ReportField>
+                    <ReportField Name="NoteActivity">
+                    </ReportField>
+                    <ReportField Name="NoteFiles">
+                    </ReportField>
+                    <ReportField Name="NoteID">
+                        <DataType>Object</DataType>
+                    </ReportField>
+                    <ReportField Name="NoteImages">
+                    </ReportField>
+                    <ReportField Name="NotePopupText">
+                    </ReportField>
+                    <ReportField Name="NoteText">
+                    </ReportField>
+                    <ReportField Name="OrigLotSerClassID">
+                    </ReportField>
+                    <ReportField Name="OvershipThreshold">
+                        <DataType>Decimal</DataType>
+                    </ReportField>
+                    <ReportField Name="PackageOption">
+                    </ReportField>
+                    <ReportField Name="PackSeparately">
+                        <DataType>Boolean</DataType>
+                    </ReportField>
+                    <ReportField Name="ParentItemClassID">
+                        <DataType>Int32</DataType>
+                    </ReportField>
+                    <ReportField Name="PendingStdCost">
+                        <DataType>Decimal</DataType>
+                    </ReportField>
+                    <ReportField Name="PendingStdCostDate">
+                        <DataType>DateTime</DataType>
+                    </ReportField>
+                    <ReportField Name="PendingStdCostDate_Day">
+                    </ReportField>
+                    <ReportField Name="PendingStdCostDate_Hour">
+                    </ReportField>
+                    <ReportField Name="PendingStdCostDate_Month">
+                    </ReportField>
+                    <ReportField Name="PendingStdCostDate_Quarter">
+                    </ReportField>
+                    <ReportField Name="PercentOfSalesPrice">
+                        <DataType>Decimal</DataType>
+                    </ReportField>
+                    <ReportField Name="PIXELSIZE_Attributes">
+                    </ReportField>
+                    <ReportField Name="POAccrualAcctID">
+                    </ReportField>
+                    <ReportField Name="POAccrualAcctID_Account_description">
+                    </ReportField>
+                    <ReportField Name="POAccrualAcctID_description">
+                    </ReportField>
+                    <ReportField Name="POAccrualAcctID_Segment1">
+                    </ReportField>
+                    <ReportField Name="POAccrualSubID">
+                    </ReportField>
+                    <ReportField Name="POAccrualSubID_description">
+                    </ReportField>
+                    <ReportField Name="POAccrualSubID_Segment1">
+                    </ReportField>
+                    <ReportField Name="POAccrualSubID_Segment2">
+                    </ReportField>
+                    <ReportField Name="POAccrualSubID_Sub_description">
+                    </ReportField>
+                    <ReportField Name="PostClassID">
+                    </ReportField>
+                    <ReportField Name="PPVAcctID">
+                    </ReportField>
+                    <ReportField Name="PPVAcctID_Account_description">
+                    </ReportField>
+                    <ReportField Name="PPVAcctID_description">
+                    </ReportField>
+                    <ReportField Name="PPVAcctID_Segment1">
+                    </ReportField>
+                    <ReportField Name="PPVSubID">
+                    </ReportField>
+                    <ReportField Name="PPVSubID_description">
+                    </ReportField>
+                    <ReportField Name="PPVSubID_Segment1">
+                    </ReportField>
+                    <ReportField Name="PPVSubID_Segment2">
+                    </ReportField>
+                    <ReportField Name="PPVSubID_Sub_description">
+                    </ReportField>
+                    <ReportField Name="PreferredVendorID">
+                    </ReportField>
+                    <ReportField Name="PreferredVendorID_BAccountR_acctName">
+                    </ReportField>
+                    <ReportField Name="PreferredVendorID_description">
+                    </ReportField>
+                    <ReportField Name="PreferredVendorID_Segment1">
+                    </ReportField>
+                    <ReportField Name="PreferredVendorID_Vendor_acctName">
+                    </ReportField>
+                    <ReportField Name="PreferredVendorLocationID">
+                    </ReportField>
+                    <ReportField Name="PreferredVendorLocationID_description">
+                    </ReportField>
+                    <ReportField Name="PreferredVendorLocationID_Location_descr">
+                    </ReportField>
+                    <ReportField Name="PreferredVendorLocationID_Segment1">
+                    </ReportField>
+                    <ReportField Name="PriceClassID">
+                    </ReportField>
+                    <ReportField Name="PriceClassID_description">
+                    </ReportField>
+                    <ReportField Name="PriceClassID_INPriceClass_description">
+                    </ReportField>
+                    <ReportField Name="PriceManagerID">
+                        <DataType>Int32</DataType>
+                    </ReportField>
+                    <ReportField Name="PriceManagerID_description">
+                    </ReportField>
+                    <ReportField Name="PriceManagerID_Owner_displayName">
+                    </ReportField>
+                    <ReportField Name="PriceWorkgroupID">
+                    </ReportField>
+                    <ReportField Name="ProductManagerID">
+                        <DataType>Int32</DataType>
+                    </ReportField>
+                    <ReportField Name="ProductManagerID_description">
+                    </ReportField>
+                    <ReportField Name="ProductManagerID_Owner_displayName">
+                    </ReportField>
+                    <ReportField Name="ProductWorkgroupID">
+                    </ReportField>
+                    <ReportField Name="PTOExpenseAcctID">
+                    </ReportField>
+                    <ReportField Name="PTOExpenseAcctID_Account_description">
+                    </ReportField>
+                    <ReportField Name="PTOExpenseAcctID_description">
+                    </ReportField>
+                    <ReportField Name="PTOExpenseAcctID_Segment1">
+                    </ReportField>
+                    <ReportField Name="PTOExpenseSubID">
+                    </ReportField>
+                    <ReportField Name="PTOExpenseSubID_description">
+                    </ReportField>
+                    <ReportField Name="PTOExpenseSubID_Segment1">
+                    </ReportField>
+                    <ReportField Name="PTOExpenseSubID_Segment2">
+                    </ReportField>
+                    <ReportField Name="PTOExpenseSubID_Sub_description">
+                    </ReportField>
+                    <ReportField Name="PurchaseUnit">
+                    </ReportField>
+                    <ReportField Name="ReasonCodeSubID">
+                    </ReportField>
+                    <ReportField Name="ReasonCodeSubID_description">
+                    </ReportField>
+                    <ReportField Name="ReasonCodeSubID_Segment1">
+                    </ReportField>
+                    <ReportField Name="ReasonCodeSubID_Segment2">
+                    </ReportField>
+                    <ReportField Name="ReasonCodeSubID_Sub_description">
+                    </ReportField>
+                    <ReportField Name="RecPrice">
+                        <DataType>Decimal</DataType>
+                    </ReportField>
+                    <ReportField Name="RESOHM_Attributes">
+                    </ReportField>
+                    <ReportField Name="RESPOWER_Attributes">
+                    </ReportField>
+                    <ReportField Name="RESTOL_Attributes">
+                    </ReportField>
+                    <ReportField Name="RowAttributeValue">
+                    </ReportField>
+                    <ReportField Name="SalesAcctID">
+                    </ReportField>
+                    <ReportField Name="SalesAcctID_Account_description">
+                    </ReportField>
+                    <ReportField Name="SalesAcctID_description">
+                    </ReportField>
+                    <ReportField Name="SalesAcctID_Segment1">
+                    </ReportField>
+                    <ReportField Name="SalesSubID">
+                    </ReportField>
+                    <ReportField Name="SalesSubID_description">
+                    </ReportField>
+                    <ReportField Name="SalesSubID_Segment1">
+                    </ReportField>
+                    <ReportField Name="SalesSubID_Segment2">
+                    </ReportField>
+                    <ReportField Name="SalesSubID_Sub_description">
+                    </ReportField>
+                    <ReportField Name="SalesUnit">
+                    </ReportField>
+                    <ReportField Name="SampleDescription">
+                    </ReportField>
+                    <ReportField Name="SampleID">
+                    </ReportField>
+                    <ReportField Name="Secured">
+                        <DataType>Boolean</DataType>
+                    </ReportField>
+                    <ReportField Name="Selected">
+                        <DataType>Boolean</DataType>
+                    </ReportField>
+                    <ReportField Name="SIZESHIRT_Attributes">
+                    </ReportField>
+                    <ReportField Name="StdCost">
+                        <DataType>Decimal</DataType>
+                    </ReportField>
+                    <ReportField Name="StdCostDate">
+                        <DataType>DateTime</DataType>
+                    </ReportField>
+                    <ReportField Name="StdCostDate_Day">
+                    </ReportField>
+                    <ReportField Name="StdCostDate_Hour">
+                    </ReportField>
+                    <ReportField Name="StdCostDate_Month">
+                    </ReportField>
+                    <ReportField Name="StdCostDate_Quarter">
+                    </ReportField>
+                    <ReportField Name="StdCstRevAcctID">
+                    </ReportField>
+                    <ReportField Name="StdCstRevAcctID_Account_description">
+                    </ReportField>
+                    <ReportField Name="StdCstRevAcctID_description">
+                    </ReportField>
+                    <ReportField Name="StdCstRevAcctID_Segment1">
+                    </ReportField>
+                    <ReportField Name="StdCstRevSubID">
+                    </ReportField>
+                    <ReportField Name="StdCstRevSubID_description">
+                    </ReportField>
+                    <ReportField Name="StdCstRevSubID_Segment1">
+                    </ReportField>
+                    <ReportField Name="StdCstRevSubID_Segment2">
+                    </ReportField>
+                    <ReportField Name="StdCstRevSubID_Sub_description">
+                    </ReportField>
+                    <ReportField Name="StdCstVarAcctID">
+                    </ReportField>
+                    <ReportField Name="StdCstVarAcctID_Account_description">
+                    </ReportField>
+                    <ReportField Name="StdCstVarAcctID_description">
+                    </ReportField>
+                    <ReportField Name="StdCstVarAcctID_Segment1">
+                    </ReportField>
+                    <ReportField Name="StdCstVarSubID">
+                    </ReportField>
+                    <ReportField Name="StdCstVarSubID_description">
+                    </ReportField>
+                    <ReportField Name="StdCstVarSubID_Segment1">
+                    </ReportField>
+                    <ReportField Name="StdCstVarSubID_Segment2">
+                    </ReportField>
+                    <ReportField Name="StdCstVarSubID_Sub_description">
+                    </ReportField>
+                    <ReportField Name="StkItem">
+                        <DataType>Boolean</DataType>
+                    </ReportField>
+                    <ReportField Name="TaxCalcMode">
+                    </ReportField>
+                    <ReportField Name="TaxCategoryID">
+                    </ReportField>
+                    <ReportField Name="TaxCategoryID_description">
+                    </ReportField>
+                    <ReportField Name="TaxCategoryID_TaxCategory_descr">
+                    </ReportField>
+                    <ReportField Name="TaxExpenseAcctID">
+                    </ReportField>
+                    <ReportField Name="TaxExpenseAcctID_Account_description">
+                    </ReportField>
+                    <ReportField Name="TaxExpenseAcctID_description">
+                    </ReportField>
+                    <ReportField Name="TaxExpenseAcctID_Segment1">
+                    </ReportField>
+                    <ReportField Name="TaxExpenseSubID">
+                    </ReportField>
+                    <ReportField Name="TaxExpenseSubID_description">
+                    </ReportField>
+                    <ReportField Name="TaxExpenseSubID_Segment1">
+                    </ReportField>
+                    <ReportField Name="TaxExpenseSubID_Segment2">
+                    </ReportField>
+                    <ReportField Name="TaxExpenseSubID_Sub_description">
+                    </ReportField>
+                    <ReportField Name="TemplateItemID">
+                    </ReportField>
+                    <ReportField Name="TemplateItemID_description">
+                    </ReportField>
+                    <ReportField Name="TemplateItemID_InventoryItem_descr">
+                    </ReportField>
+                    <ReportField Name="TemplateItemID_Segment1">
+                    </ReportField>
+                    <ReportField Name="TotalPercentage">
+                        <DataType>Decimal</DataType>
+                    </ReportField>
+                    <ReportField Name="tstamp">
+                    </ReportField>
+                    <ReportField Name="UndershipThreshold">
+                        <DataType>Decimal</DataType>
+                    </ReportField>
+                    <ReportField Name="UpdateOnlySelected">
+                        <DataType>Boolean</DataType>
+                    </ReportField>
+                    <ReportField Name="UseParentSubID">
+                        <DataType>Boolean</DataType>
+                    </ReportField>
+                    <ReportField Name="ValMethod">
+                    </ReportField>
+                    <ReportField Name="Visibility">
+                    </ReportField>
+                    <ReportField Name="VolumeUOM">
+                    </ReportField>
+                    <ReportField Name="WeightItem">
+                        <DataType>Boolean</DataType>
+                    </ReportField>
+                    <ReportField Name="WeightUOM">
+                    </ReportField>
+                    <ReportField Name="WIDEANGLE_Attributes">
+                    </ReportField>
+                </Fields>
+                <FullName>PX.Objects.IN.InventoryItem</FullName>
+            </ReportTable>
+        </Tables>
+        <Version>20211215</Version>
+        <Sections>
+            <PageHeader Name="pageHeaderSection1">
+                <Height>0.21164cm</Height>
+            </PageHeader>
+            <Detail Name="detailSection1">
+                <Height>0.63492cm</Height>
+                <Items>
+                    <TextBox Name="textBox1">
+                        <Location>8px, 0px</Location>
+                        <Size>48px, 24px</Size>
+                        <Value>=[WOLineItem.LineNbr]</Value>
+                    </TextBox>
+                    <TextBox Name="textBox2">
+                        <Location>488px, 0px</Location>
+                        <Size>120px, 24px</Size>
+                        <Value>=[WOLineItem.Quantity]</Value>
+                    </TextBox>
+                    <TextBox Name="textBox3">
+                        <Location>64px, 0px</Location>
+                        <Size>120px, 24px</Size>
+                        <Value>=[InventoryItem.InventoryCD]</Value>
+                    </TextBox>
+                    <TextBox Name="textBox4">
+                        <Location>192px, 0px</Location>
+                        <Size>288px, 24px</Size>
+                        <Value>=[InventoryItem.Descr]</Value>
+                    </TextBox>
+                </Items>
+            </Detail>
+            <PageFooter Name="pageFooterSection1">
+                <Height>0.21164cm</Height>
+            </PageFooter>
+        </Sections>
+    </Report>
+</Report>

--- a/Package/CMMS/_project/REPORT_WO602004_RPX.xml
+++ b/Package/CMMS/_project/REPORT_WO602004_RPX.xml
@@ -1,0 +1,136 @@
+﻿<Report Name="wo602004.rpx">
+    <Report version="20211215" Name="report1">
+        <Filters>
+            <FilterExp>
+                <DataField>WOLineTool.WorkOrderID</DataField>
+                <Value>@WorkOrderID</Value>
+            </FilterExp>
+            <FilterExp>
+                <DataField>WOLineTool.WOLineNbr</DataField>
+                <Value>@LineNbr</Value>
+            </FilterExp>
+        </Filters>
+        <Parameters>
+            <ReportParameter>
+                <Name>WorkOrderID</Name>
+            </ReportParameter>
+            <ReportParameter>
+                <Name>LineNbr</Name>
+            </ReportParameter>
+        </Parameters>
+        <SchemaUrl>http://localhost/CMMS</SchemaUrl>
+        <Tables>
+            <ReportTable Name="WOLineTool">
+                <Fields>
+                    <ReportField Name="BaseUnit">
+                    </ReportField>
+                    <ReportField Name="CreatedByID">
+                    </ReportField>
+                    <ReportField Name="CreatedByID_Creator_displayName">
+                    </ReportField>
+                    <ReportField Name="CreatedByID_Creator_Username">
+                    </ReportField>
+                    <ReportField Name="CreatedByID_description">
+                    </ReportField>
+                    <ReportField Name="CreatedByScreenID">
+                    </ReportField>
+                    <ReportField Name="CreatedDateTime">
+                        <DataType>DateTime</DataType>
+                    </ReportField>
+                    <ReportField Name="CreatedDateTime_Day">
+                    </ReportField>
+                    <ReportField Name="CreatedDateTime_Hour">
+                    </ReportField>
+                    <ReportField Name="CreatedDateTime_Month">
+                    </ReportField>
+                    <ReportField Name="CreatedDateTime_Quarter">
+                    </ReportField>
+                    <ReportField Name="InventoryID">
+                    </ReportField>
+                    <ReportField Name="InventoryID_description">
+                    </ReportField>
+                    <ReportField Name="InventoryID_InventoryItem_descr">
+                    </ReportField>
+                    <ReportField Name="InventoryID_Segment1">
+                    </ReportField>
+                    <ReportField Name="LastModifiedByID">
+                    </ReportField>
+                    <ReportField Name="LastModifiedByID_description">
+                    </ReportField>
+                    <ReportField Name="LastModifiedByID_Modifier_displayName">
+                    </ReportField>
+                    <ReportField Name="LastModifiedByID_Modifier_Username">
+                    </ReportField>
+                    <ReportField Name="LastModifiedByScreenID">
+                    </ReportField>
+                    <ReportField Name="LastModifiedDateTime">
+                        <DataType>DateTime</DataType>
+                    </ReportField>
+                    <ReportField Name="LastModifiedDateTime_Day">
+                    </ReportField>
+                    <ReportField Name="LastModifiedDateTime_Hour">
+                    </ReportField>
+                    <ReportField Name="LastModifiedDateTime_Month">
+                    </ReportField>
+                    <ReportField Name="LastModifiedDateTime_Quarter">
+                    </ReportField>
+                    <ReportField Name="LineNbr">
+                        <DataType>Int32</DataType>
+                    </ReportField>
+                    <ReportField Name="NoteActivity">
+                    </ReportField>
+                    <ReportField Name="NoteFiles">
+                    </ReportField>
+                    <ReportField Name="NoteID">
+                        <DataType>Object</DataType>
+                    </ReportField>
+                    <ReportField Name="NoteImages">
+                    </ReportField>
+                    <ReportField Name="NoteText">
+                    </ReportField>
+                    <ReportField Name="Quantity">
+                        <DataType>Decimal</DataType>
+                    </ReportField>
+                    <ReportField Name="Tstamp">
+                    </ReportField>
+                    <ReportField Name="WOLineNbr">
+                        <DataType>Int32</DataType>
+                    </ReportField>
+                    <ReportField Name="WorkOrderID">
+                        <DataType>Int32</DataType>
+                    </ReportField>
+                </Fields>
+                <FullName>CMMSlite.WO.WOLineTool</FullName>
+            </ReportTable>
+        </Tables>
+        <Version>20211215</Version>
+        <Sections>
+            <PageHeader Name="pageHeaderSection1">
+                <Height>0.21164cm</Height>
+            </PageHeader>
+            <Detail Name="detailSection1">
+                <Height>0.63492cm</Height>
+                <Items>
+                    <TextBox Name="textBox1">
+                        <Location>0px, 0px</Location>
+                        <Size>120px, 24px</Size>
+                        <Value>=[WOLineTool.EquipmentID]</Value>
+                    </TextBox>
+                    <TextBox Name="textBox2">
+                        <Location>128px, 0px</Location>
+                        <Size>432px, 24px</Size>
+                        <Value>=[WOLineTool.EquipmentID_description]</Value>
+                    </TextBox>
+                    <TextBox Name="textBox3">
+                        <Location>568px, 0px</Location>
+                        <Size>120px, 24px</Size>
+                        <Value>=[WOLineTool.Quantity]</Value>
+                    </TextBox>
+                </Items>
+            </Detail>
+            <PageFooter Name="pageFooterSection1">
+                <Height>0.21164cm</Height>
+            </PageFooter>
+        </Sections>
+    </Report>
+</Report>

--- a/Package/CMMS/_project/REPORT_WO602005_RPX.xml
+++ b/Package/CMMS/_project/REPORT_WO602005_RPX.xml
@@ -1,0 +1,207 @@
+﻿<Report Name="wo602005.rpx">
+    <Report version="20211215" Name="report1">
+        <Filters>
+            <FilterExp>
+                <DataField>WOLineMeasure.WorkOrderID</DataField>
+                <Value>@WorkOrderID</Value>
+            </FilterExp>
+            <FilterExp>
+                <DataField>WOLineMeasure.WOLineNbr</DataField>
+                <Value>@LineNbr</Value>
+            </FilterExp>
+        </Filters>
+        <Parameters>
+            <ReportParameter>
+                <Name>WorkOrderID</Name>
+            </ReportParameter>
+            <ReportParameter>
+                <Name>LineNbr</Name>
+            </ReportParameter>
+        </Parameters>
+        <Relations>
+            <ReportRelation>
+                <ChildName>WOMeasurement</ChildName>
+                <Links>
+                    <RelationRow>
+                        <ChildField>MeasurementID</ChildField>
+                        <ParentField>MeasurementID</ParentField>
+                    </RelationRow>
+                </Links>
+                <ParentName>WOLineMeasure</ParentName>
+            </ReportRelation>
+        </Relations>
+        <SchemaUrl>http://localhost/CMMS</SchemaUrl>
+        <Tables>
+            <ReportTable Name="WOLineMeasure">
+                <Fields>
+                    <ReportField Name="CreatedByID">
+                    </ReportField>
+                    <ReportField Name="CreatedByID_Creator_displayName">
+                    </ReportField>
+                    <ReportField Name="CreatedByID_Creator_Username">
+                    </ReportField>
+                    <ReportField Name="CreatedByID_description">
+                    </ReportField>
+                    <ReportField Name="CreatedByScreenID">
+                    </ReportField>
+                    <ReportField Name="CreatedDateTime">
+                        <DataType>DateTime</DataType>
+                    </ReportField>
+                    <ReportField Name="CreatedDateTime_Day">
+                    </ReportField>
+                    <ReportField Name="CreatedDateTime_Hour">
+                    </ReportField>
+                    <ReportField Name="CreatedDateTime_Month">
+                    </ReportField>
+                    <ReportField Name="CreatedDateTime_Quarter">
+                    </ReportField>
+                    <ReportField Name="LastModifiedByID">
+                    </ReportField>
+                    <ReportField Name="LastModifiedByID_description">
+                    </ReportField>
+                    <ReportField Name="LastModifiedByID_Modifier_displayName">
+                    </ReportField>
+                    <ReportField Name="LastModifiedByID_Modifier_Username">
+                    </ReportField>
+                    <ReportField Name="LastModifiedByScreenID">
+                    </ReportField>
+                    <ReportField Name="LastModifiedDateTime">
+                        <DataType>DateTime</DataType>
+                    </ReportField>
+                    <ReportField Name="LastModifiedDateTime_Day">
+                    </ReportField>
+                    <ReportField Name="LastModifiedDateTime_Hour">
+                    </ReportField>
+                    <ReportField Name="LastModifiedDateTime_Month">
+                    </ReportField>
+                    <ReportField Name="LastModifiedDateTime_Quarter">
+                    </ReportField>
+                    <ReportField Name="LineNbr">
+                        <DataType>Int32</DataType>
+                    </ReportField>
+                    <ReportField Name="MeasurementID">
+                    </ReportField>
+                    <ReportField Name="NoteActivity">
+                    </ReportField>
+                    <ReportField Name="NoteFiles">
+                    </ReportField>
+                    <ReportField Name="NoteID">
+                        <DataType>Object</DataType>
+                    </ReportField>
+                    <ReportField Name="NoteImages">
+                    </ReportField>
+                    <ReportField Name="NoteText">
+                    </ReportField>
+                    <ReportField Name="Tstamp">
+                    </ReportField>
+                    <ReportField Name="Value">
+                        <DataType>Decimal</DataType>
+                    </ReportField>
+                    <ReportField Name="WOLineNbr">
+                        <DataType>Int32</DataType>
+                    </ReportField>
+                    <ReportField Name="WorkOrderID">
+                        <DataType>Int32</DataType>
+                    </ReportField>
+                </Fields>
+                <FullName>CMMSlite.WO.WOLineMeasure</FullName>
+            </ReportTable>
+            <ReportTable Name="WOMeasurement">
+                <Fields>
+                    <ReportField Name="CreatedByID">
+                    </ReportField>
+                    <ReportField Name="CreatedByID_Creator_displayName">
+                    </ReportField>
+                    <ReportField Name="CreatedByID_Creator_Username">
+                    </ReportField>
+                    <ReportField Name="CreatedByID_description">
+                    </ReportField>
+                    <ReportField Name="CreatedByScreenID">
+                    </ReportField>
+                    <ReportField Name="CreatedDateTime">
+                        <DataType>DateTime</DataType>
+                    </ReportField>
+                    <ReportField Name="CreatedDateTime_Day">
+                    </ReportField>
+                    <ReportField Name="CreatedDateTime_Hour">
+                    </ReportField>
+                    <ReportField Name="CreatedDateTime_Month">
+                    </ReportField>
+                    <ReportField Name="CreatedDateTime_Quarter">
+                    </ReportField>
+                    <ReportField Name="Descr">
+                    </ReportField>
+                    <ReportField Name="LastModifiedByID">
+                    </ReportField>
+                    <ReportField Name="LastModifiedByID_description">
+                    </ReportField>
+                    <ReportField Name="LastModifiedByID_Modifier_displayName">
+                    </ReportField>
+                    <ReportField Name="LastModifiedByID_Modifier_Username">
+                    </ReportField>
+                    <ReportField Name="LastModifiedByScreenID">
+                    </ReportField>
+                    <ReportField Name="LastModifiedDateTime">
+                        <DataType>DateTime</DataType>
+                    </ReportField>
+                    <ReportField Name="LastModifiedDateTime_Day">
+                    </ReportField>
+                    <ReportField Name="LastModifiedDateTime_Hour">
+                    </ReportField>
+                    <ReportField Name="LastModifiedDateTime_Month">
+                    </ReportField>
+                    <ReportField Name="LastModifiedDateTime_Quarter">
+                    </ReportField>
+                    <ReportField Name="MeasurementCD">
+                    </ReportField>
+                    <ReportField Name="MeasurementID">
+                        <DataType>Int32</DataType>
+                    </ReportField>
+                    <ReportField Name="NoteActivity">
+                    </ReportField>
+                    <ReportField Name="NoteFiles">
+                    </ReportField>
+                    <ReportField Name="NoteID">
+                        <DataType>Object</DataType>
+                    </ReportField>
+                    <ReportField Name="NoteImages">
+                    </ReportField>
+                    <ReportField Name="NoteText">
+                    </ReportField>
+                    <ReportField Name="Tstamp">
+                    </ReportField>
+                </Fields>
+                <FullName>CMMSlite.WOMeasurement</FullName>
+            </ReportTable>
+        </Tables>
+        <Version>20211215</Version>
+        <Sections>
+            <PageHeader Name="pageHeaderSection1">
+                <Height>0.21164cm</Height>
+            </PageHeader>
+            <Detail Name="detailSection1">
+                <Height>0.63492cm</Height>
+                <Items>
+                    <TextBox Name="textBox1">
+                        <Location>0px, 0px</Location>
+                        <Size>120px, 24px</Size>
+                        <Value>=[WOMeasurement.MeasurementCD]</Value>
+                    </TextBox>
+                    <TextBox Name="textBox2">
+                        <Location>128px, 0px</Location>
+                        <Size>320px, 24px</Size>
+                        <Value>=[WOMeasurement.Descr]</Value>
+                    </TextBox>
+                    <TextBox Name="textBox3">
+                        <Location>456px, 0px</Location>
+                        <Size>120px, 24px</Size>
+                        <Value>=[WOLineMeasure.Value]</Value>
+                    </TextBox>
+                </Items>
+            </Detail>
+            <PageFooter Name="pageFooterSection1">
+                <Height>0.21164cm</Height>
+            </PageFooter>
+        </Sections>
+    </Report>
+</Report>

--- a/Package/CMMS/_project/REPORT_WO602006_RPX.xml
+++ b/Package/CMMS/_project/REPORT_WO602006_RPX.xml
@@ -1,0 +1,206 @@
+﻿<Report Name="wo602006.rpx">
+    <Report version="20211215" Name="report1">
+        <Filters>
+            <FilterExp>
+                <DataField>WOLineFailure.WorkOrderID</DataField>
+                <Value>@WorkOrderID</Value>
+            </FilterExp>
+            <FilterExp>
+                <DataField>WOLineFailure.WOLineNbr</DataField>
+                <Value>@LineNbr</Value>
+            </FilterExp>
+        </Filters>
+        <Parameters>
+            <ReportParameter>
+                <Name>WorkOrderID</Name>
+            </ReportParameter>
+            <ReportParameter>
+                <Name>LineNbr</Name>
+            </ReportParameter>
+        </Parameters>
+        <Relations>
+            <ReportRelation>
+                <ChildName>WOFailureMode</ChildName>
+                <Links>
+                    <RelationRow>
+                        <ChildField>FailureModeID</ChildField>
+                        <ParentField>FailureModeID</ParentField>
+                    </RelationRow>
+                </Links>
+                <ParentName>WOLineFailure</ParentName>
+            </ReportRelation>
+        </Relations>
+        <SchemaUrl>http://localhost/CMMS</SchemaUrl>
+        <Tables>
+            <ReportTable Name="WOLineFailure">
+                <Fields>
+                    <ReportField Name="Comment">
+                    </ReportField>
+                    <ReportField Name="CreatedByID">
+                    </ReportField>
+                    <ReportField Name="CreatedByID_Creator_displayName">
+                    </ReportField>
+                    <ReportField Name="CreatedByID_Creator_Username">
+                    </ReportField>
+                    <ReportField Name="CreatedByID_description">
+                    </ReportField>
+                    <ReportField Name="CreatedByScreenID">
+                    </ReportField>
+                    <ReportField Name="CreatedDateTime">
+                        <DataType>DateTime</DataType>
+                    </ReportField>
+                    <ReportField Name="CreatedDateTime_Day">
+                    </ReportField>
+                    <ReportField Name="CreatedDateTime_Hour">
+                    </ReportField>
+                    <ReportField Name="CreatedDateTime_Month">
+                    </ReportField>
+                    <ReportField Name="CreatedDateTime_Quarter">
+                    </ReportField>
+                    <ReportField Name="FailureModeID">
+                    </ReportField>
+                    <ReportField Name="LastModifiedByID">
+                    </ReportField>
+                    <ReportField Name="LastModifiedByID_description">
+                    </ReportField>
+                    <ReportField Name="LastModifiedByID_Modifier_displayName">
+                    </ReportField>
+                    <ReportField Name="LastModifiedByID_Modifier_Username">
+                    </ReportField>
+                    <ReportField Name="LastModifiedByScreenID">
+                    </ReportField>
+                    <ReportField Name="LastModifiedDateTime">
+                        <DataType>DateTime</DataType>
+                    </ReportField>
+                    <ReportField Name="LastModifiedDateTime_Day">
+                    </ReportField>
+                    <ReportField Name="LastModifiedDateTime_Hour">
+                    </ReportField>
+                    <ReportField Name="LastModifiedDateTime_Month">
+                    </ReportField>
+                    <ReportField Name="LastModifiedDateTime_Quarter">
+                    </ReportField>
+                    <ReportField Name="LineNbr">
+                        <DataType>Int32</DataType>
+                    </ReportField>
+                    <ReportField Name="NoteActivity">
+                    </ReportField>
+                    <ReportField Name="NoteFiles">
+                    </ReportField>
+                    <ReportField Name="NoteID">
+                        <DataType>Object</DataType>
+                    </ReportField>
+                    <ReportField Name="NoteImages">
+                    </ReportField>
+                    <ReportField Name="NoteText">
+                    </ReportField>
+                    <ReportField Name="Tstamp">
+                    </ReportField>
+                    <ReportField Name="WOLineNbr">
+                        <DataType>Int32</DataType>
+                    </ReportField>
+                    <ReportField Name="WorkOrderID">
+                        <DataType>Int32</DataType>
+                    </ReportField>
+                </Fields>
+                <FullName>CMMSlite.WO.WOLineFailure</FullName>
+            </ReportTable>
+            <ReportTable Name="WOFailureMode">
+                <Fields>
+                    <ReportField Name="CreatedByID">
+                    </ReportField>
+                    <ReportField Name="CreatedByID_Creator_displayName">
+                    </ReportField>
+                    <ReportField Name="CreatedByID_Creator_Username">
+                    </ReportField>
+                    <ReportField Name="CreatedByID_description">
+                    </ReportField>
+                    <ReportField Name="CreatedByScreenID">
+                    </ReportField>
+                    <ReportField Name="CreatedDateTime">
+                        <DataType>DateTime</DataType>
+                    </ReportField>
+                    <ReportField Name="CreatedDateTime_Day">
+                    </ReportField>
+                    <ReportField Name="CreatedDateTime_Hour">
+                    </ReportField>
+                    <ReportField Name="CreatedDateTime_Month">
+                    </ReportField>
+                    <ReportField Name="CreatedDateTime_Quarter">
+                    </ReportField>
+                    <ReportField Name="Descr">
+                    </ReportField>
+                    <ReportField Name="FailureModeCD">
+                    </ReportField>
+                    <ReportField Name="FailureModeID">
+                        <DataType>Int32</DataType>
+                    </ReportField>
+                    <ReportField Name="LastModifiedByID">
+                    </ReportField>
+                    <ReportField Name="LastModifiedByID_description">
+                    </ReportField>
+                    <ReportField Name="LastModifiedByID_Modifier_displayName">
+                    </ReportField>
+                    <ReportField Name="LastModifiedByID_Modifier_Username">
+                    </ReportField>
+                    <ReportField Name="LastModifiedByScreenID">
+                    </ReportField>
+                    <ReportField Name="LastModifiedDateTime">
+                        <DataType>DateTime</DataType>
+                    </ReportField>
+                    <ReportField Name="LastModifiedDateTime_Day">
+                    </ReportField>
+                    <ReportField Name="LastModifiedDateTime_Hour">
+                    </ReportField>
+                    <ReportField Name="LastModifiedDateTime_Month">
+                    </ReportField>
+                    <ReportField Name="LastModifiedDateTime_Quarter">
+                    </ReportField>
+                    <ReportField Name="NoteActivity">
+                    </ReportField>
+                    <ReportField Name="NoteFiles">
+                    </ReportField>
+                    <ReportField Name="NoteID">
+                        <DataType>Object</DataType>
+                    </ReportField>
+                    <ReportField Name="NoteImages">
+                    </ReportField>
+                    <ReportField Name="NoteText">
+                    </ReportField>
+                    <ReportField Name="Tstamp">
+                    </ReportField>
+                </Fields>
+                <FullName>CMMSlite.WOFailureMode</FullName>
+            </ReportTable>
+        </Tables>
+        <Version>20211215</Version>
+        <Sections>
+            <PageHeader Name="pageHeaderSection1">
+                <Height>0.21164cm</Height>
+            </PageHeader>
+            <Detail Name="detailSection1">
+                <Height>0.63492cm</Height>
+                <Items>
+                    <TextBox Name="textBox1">
+                        <Location>344px, 0px</Location>
+                        <Size>344px, 24px</Size>
+                        <Value>=[WOLineFailure.Comment]</Value>
+                    </TextBox>
+                    <TextBox Name="textBox2">
+                        <Location>8px, 0px</Location>
+                        <Size>120px, 24px</Size>
+                        <Value>=[WOFailureMode.FailureModeCD]</Value>
+                    </TextBox>
+                    <TextBox Name="textBox3">
+                        <Location>136px, 0px</Location>
+                        <Size>200px, 24px</Size>
+                        <Value>=[WOFailureMode.Descr]</Value>
+                    </TextBox>
+                </Items>
+            </Detail>
+            <PageFooter Name="pageFooterSection1">
+                <Height>0.21164cm</Height>
+            </PageFooter>
+        </Sections>
+    </Report>
+</Report>

--- a/Package/CMMS/_project/REPORT_WO603000_RPX.xml
+++ b/Package/CMMS/_project/REPORT_WO603000_RPX.xml
@@ -1,0 +1,677 @@
+﻿<Report Name="wo603000.rpx">
+    <Report version="20211215" Name="report1">
+        <Filters>
+            <FilterExp>
+                <DataField>WOOrder.WorkOrderCD</DataField>
+                <OpenBraces>1</OpenBraces>
+                <Operator>Or</Operator>
+                <Value>@WorkOrderID</Value>
+            </FilterExp>
+            <FilterExp>
+                <CloseBraces>1</CloseBraces>
+                <Condition>IsNull</Condition>
+                <DataField>@WorkOrderID</DataField>
+            </FilterExp>
+            <FilterExp>
+                <DataField>WOOrder.Status</DataField>
+                <OpenBraces>1</OpenBraces>
+                <Operator>Or</Operator>
+                <Value>@Status</Value>
+            </FilterExp>
+            <FilterExp>
+                <CloseBraces>1</CloseBraces>
+                <Condition>IsNull</Condition>
+                <DataField>@Status</DataField>
+            </FilterExp>
+            <FilterExp>
+                <DataField>WOOrder.WorkOrderType</DataField>
+                <OpenBraces>1</OpenBraces>
+                <Operator>Or</Operator>
+                <Value>@WorkOrderType</Value>
+            </FilterExp>
+            <FilterExp>
+                <CloseBraces>1</CloseBraces>
+                <Condition>IsNull</Condition>
+                <DataField>@WorkOrderType</DataField>
+            </FilterExp>
+        </Filters>
+        <LayoutUnit>Inch</LayoutUnit>
+        <PageSettings>
+            <Margins>
+            </Margins>
+            <PaperKind>Letter</PaperKind>
+        </PageSettings>
+        <Parameters>
+            <ReportParameter>
+                <Name>WorkOrderID</Name>
+                <Nullable>True</Nullable>
+                <Prompt>Work Order ID</Prompt>
+                <ViewName>=Report.GetFieldSchema('WOOrder.WorkOrderCD')</ViewName>
+            </ReportParameter>
+            <ReportParameter>
+                <Name>Status</Name>
+                <Nullable>True</Nullable>
+                <Prompt>Status</Prompt>
+                <ViewName>=Report.GetFieldSchema('WOOrder.Status')</ViewName>
+            </ReportParameter>
+            <ReportParameter>
+                <Name>WorkOrderType</Name>
+                <Nullable>True</Nullable>
+                <Prompt>Type</Prompt>
+                <ViewName>=Report.GetFieldSchema('WOOrder.WorkOrderType')</ViewName>
+            </ReportParameter>
+        </Parameters>
+        <Relations>
+            <ReportRelation>
+                <ChildName>WOClass</ChildName>
+                <Links>
+                    <RelationRow>
+                        <ChildField>WOClassID</ChildField>
+                        <ParentField>WOClassID</ParentField>
+                    </RelationRow>
+                </Links>
+                <ParentName>WOOrder</ParentName>
+            </ReportRelation>
+            <ReportRelation>
+                <ChildName>WOEquipment</ChildName>
+                <Links>
+                    <RelationRow>
+                        <ChildField>EquipmentID</ChildField>
+                        <ParentField>EquipmentID</ParentField>
+                    </RelationRow>
+                </Links>
+                <ParentName>WOOrder</ParentName>
+            </ReportRelation>
+        </Relations>
+        <SchemaUrl>http://localhost/CMMS</SchemaUrl>
+        <Tables>
+            <ReportTable Name="WOOrder">
+                <Fields>
+                    <ReportField Name="AMBATCOLOR_Attributes">
+                    </ReportField>
+                    <ReportField Name="AMBATLEN_Attributes">
+                    </ReportField>
+                    <ReportField Name="AMBATPT_Attributes">
+                    </ReportField>
+                    <ReportField Name="AMBATWGT_Attributes">
+                    </ReportField>
+                    <ReportField Name="Approved">
+                        <DataType>Boolean</DataType>
+                    </ReportField>
+                    <ReportField Name="BranchID">
+                        <DataType>Int32</DataType>
+                    </ReportField>
+                    <ReportField Name="ClassID">
+                    </ReportField>
+                    <ReportField Name="CreatedByID">
+                    </ReportField>
+                    <ReportField Name="CreatedByID_Creator_displayName">
+                    </ReportField>
+                    <ReportField Name="CreatedByID_Creator_Username">
+                    </ReportField>
+                    <ReportField Name="CreatedByID_description">
+                    </ReportField>
+                    <ReportField Name="CreatedByScreenID">
+                    </ReportField>
+                    <ReportField Name="CreatedDateTime">
+                        <DataType>DateTime</DataType>
+                    </ReportField>
+                    <ReportField Name="CreatedDateTime_Day">
+                    </ReportField>
+                    <ReportField Name="CreatedDateTime_Hour">
+                    </ReportField>
+                    <ReportField Name="CreatedDateTime_Month">
+                    </ReportField>
+                    <ReportField Name="CreatedDateTime_Quarter">
+                    </ReportField>
+                    <ReportField Name="Descr">
+                    </ReportField>
+                    <ReportField Name="EquipmentID">
+                    </ReportField>
+                    <ReportField Name="EquipmentID_description">
+                    </ReportField>
+                    <ReportField Name="EquipmentID_WOEquipment_descr">
+                    </ReportField>
+                    <ReportField Name="FSRESOL_Attributes">
+                    </ReportField>
+                    <ReportField Name="HANDS_Attributes">
+                    </ReportField>
+                    <ReportField Name="Hold">
+                        <DataType>Boolean</DataType>
+                    </ReportField>
+                    <ReportField Name="LastLineNbr">
+                        <DataType>Int32</DataType>
+                    </ReportField>
+                    <ReportField Name="LastModifiedByID">
+                    </ReportField>
+                    <ReportField Name="LastModifiedByID_description">
+                    </ReportField>
+                    <ReportField Name="LastModifiedByID_Modifier_displayName">
+                    </ReportField>
+                    <ReportField Name="LastModifiedByID_Modifier_Username">
+                    </ReportField>
+                    <ReportField Name="LastModifiedByScreenID">
+                    </ReportField>
+                    <ReportField Name="LastModifiedDateTime">
+                        <DataType>DateTime</DataType>
+                    </ReportField>
+                    <ReportField Name="LastModifiedDateTime_Day">
+                    </ReportField>
+                    <ReportField Name="LastModifiedDateTime_Hour">
+                    </ReportField>
+                    <ReportField Name="LastModifiedDateTime_Month">
+                    </ReportField>
+                    <ReportField Name="LastModifiedDateTime_Quarter">
+                    </ReportField>
+                    <ReportField Name="NoteActivity">
+                    </ReportField>
+                    <ReportField Name="NoteFiles">
+                    </ReportField>
+                    <ReportField Name="NoteID">
+                        <DataType>Object</DataType>
+                    </ReportField>
+                    <ReportField Name="NoteImages">
+                    </ReportField>
+                    <ReportField Name="NoteText">
+                    </ReportField>
+                    <ReportField Name="OrigWorkOrderID">
+                        <DataType>Int32</DataType>
+                    </ReportField>
+                    <ReportField Name="OwnerID">
+                        <DataType>Int32</DataType>
+                    </ReportField>
+                    <ReportField Name="OwnerID_description">
+                    </ReportField>
+                    <ReportField Name="OwnerID_Owner_displayName">
+                    </ReportField>
+                    <ReportField Name="Priority">
+                    </ReportField>
+                    <ReportField Name="Rejected">
+                        <DataType>Boolean</DataType>
+                    </ReportField>
+                    <ReportField Name="RequestApproval">
+                        <DataType>Boolean</DataType>
+                    </ReportField>
+                    <ReportField Name="RequestDate">
+                        <DataType>DateTime</DataType>
+                    </ReportField>
+                    <ReportField Name="RequestDate_Day">
+                    </ReportField>
+                    <ReportField Name="RequestDate_Hour">
+                    </ReportField>
+                    <ReportField Name="RequestDate_Month">
+                    </ReportField>
+                    <ReportField Name="RequestDate_Quarter">
+                    </ReportField>
+                    <ReportField Name="ScheduleDate">
+                        <DataType>DateTime</DataType>
+                    </ReportField>
+                    <ReportField Name="ScheduleDate_Day">
+                    </ReportField>
+                    <ReportField Name="ScheduleDate_Hour">
+                    </ReportField>
+                    <ReportField Name="ScheduleDate_Month">
+                    </ReportField>
+                    <ReportField Name="ScheduleDate_Quarter">
+                    </ReportField>
+                    <ReportField Name="Selected">
+                        <DataType>Boolean</DataType>
+                    </ReportField>
+                    <ReportField Name="Status">
+                    </ReportField>
+                    <ReportField Name="Tstamp">
+                    </ReportField>
+                    <ReportField Name="WOClassID">
+                    </ReportField>
+                    <ReportField Name="WorkgroupID">
+                    </ReportField>
+                    <ReportField Name="WorkOrderCD">
+                    </ReportField>
+                    <ReportField Name="WorkOrderID">
+                        <DataType>Int32</DataType>
+                    </ReportField>
+                    <ReportField Name="WorkOrderType">
+                    </ReportField>
+                </Fields>
+                <FullName>CMMSlite.WO.WOOrder</FullName>
+            </ReportTable>
+            <ReportTable Name="WOClass">
+                <Fields>
+                    <ReportField Name="CreatedByID">
+                    </ReportField>
+                    <ReportField Name="CreatedByID_Creator_displayName">
+                    </ReportField>
+                    <ReportField Name="CreatedByID_Creator_Username">
+                    </ReportField>
+                    <ReportField Name="CreatedByID_description">
+                    </ReportField>
+                    <ReportField Name="CreatedByScreenID">
+                    </ReportField>
+                    <ReportField Name="CreatedDateTime">
+                        <DataType>DateTime</DataType>
+                    </ReportField>
+                    <ReportField Name="CreatedDateTime_Day">
+                    </ReportField>
+                    <ReportField Name="CreatedDateTime_Hour">
+                    </ReportField>
+                    <ReportField Name="CreatedDateTime_Month">
+                    </ReportField>
+                    <ReportField Name="CreatedDateTime_Quarter">
+                    </ReportField>
+                    <ReportField Name="Descr">
+                    </ReportField>
+                    <ReportField Name="LastModifiedByID">
+                    </ReportField>
+                    <ReportField Name="LastModifiedByID_description">
+                    </ReportField>
+                    <ReportField Name="LastModifiedByID_Modifier_displayName">
+                    </ReportField>
+                    <ReportField Name="LastModifiedByID_Modifier_Username">
+                    </ReportField>
+                    <ReportField Name="LastModifiedByScreenID">
+                    </ReportField>
+                    <ReportField Name="LastModifiedDateTime">
+                        <DataType>DateTime</DataType>
+                    </ReportField>
+                    <ReportField Name="LastModifiedDateTime_Day">
+                    </ReportField>
+                    <ReportField Name="LastModifiedDateTime_Hour">
+                    </ReportField>
+                    <ReportField Name="LastModifiedDateTime_Month">
+                    </ReportField>
+                    <ReportField Name="LastModifiedDateTime_Quarter">
+                    </ReportField>
+                    <ReportField Name="NoteActivity">
+                    </ReportField>
+                    <ReportField Name="NoteFiles">
+                    </ReportField>
+                    <ReportField Name="NoteID">
+                        <DataType>Object</DataType>
+                    </ReportField>
+                    <ReportField Name="NoteImages">
+                    </ReportField>
+                    <ReportField Name="NoteText">
+                    </ReportField>
+                    <ReportField Name="Tstamp">
+                    </ReportField>
+                    <ReportField Name="WOClassID">
+                    </ReportField>
+                </Fields>
+                <FullName>CMMSlite.WO.WOClass</FullName>
+            </ReportTable>
+            <ReportTable Name="WOEquipment">
+                <Fields>
+                    <ReportField Name="AMMachID">
+                    </ReportField>
+                    <ReportField Name="AMMachID_AMMach_descr">
+                    </ReportField>
+                    <ReportField Name="AMMachID_description">
+                    </ReportField>
+                    <ReportField Name="AssetID">
+                    </ReportField>
+                    <ReportField Name="BranchID">
+                    </ReportField>
+                    <ReportField Name="BranchID_Branch_acctName">
+                    </ReportField>
+                    <ReportField Name="BranchID_description">
+                    </ReportField>
+                    <ReportField Name="BranchID_Segment1">
+                    </ReportField>
+                    <ReportField Name="CreatedByID">
+                    </ReportField>
+                    <ReportField Name="CreatedByID_Creator_displayName">
+                    </ReportField>
+                    <ReportField Name="CreatedByID_Creator_Username">
+                    </ReportField>
+                    <ReportField Name="CreatedByID_description">
+                    </ReportField>
+                    <ReportField Name="CreatedByScreenID">
+                    </ReportField>
+                    <ReportField Name="CreatedDateTime">
+                        <DataType>DateTime</DataType>
+                    </ReportField>
+                    <ReportField Name="CreatedDateTime_Day">
+                    </ReportField>
+                    <ReportField Name="CreatedDateTime_Hour">
+                    </ReportField>
+                    <ReportField Name="CreatedDateTime_Month">
+                    </ReportField>
+                    <ReportField Name="CreatedDateTime_Quarter">
+                    </ReportField>
+                    <ReportField Name="Criticality">
+                    </ReportField>
+                    <ReportField Name="DateInstalled">
+                        <DataType>DateTime</DataType>
+                    </ReportField>
+                    <ReportField Name="DateInstalled_Day">
+                    </ReportField>
+                    <ReportField Name="DateInstalled_Hour">
+                    </ReportField>
+                    <ReportField Name="DateInstalled_Month">
+                    </ReportField>
+                    <ReportField Name="DateInstalled_Quarter">
+                    </ReportField>
+                    <ReportField Name="DepartmentID">
+                    </ReportField>
+                    <ReportField Name="DepartmentID_description">
+                    </ReportField>
+                    <ReportField Name="DepartmentID_EPDepartment_description">
+                    </ReportField>
+                    <ReportField Name="Descr">
+                    </ReportField>
+                    <ReportField Name="EquipmentCD">
+                    </ReportField>
+                    <ReportField Name="EquipmentID">
+                        <DataType>Int32</DataType>
+                    </ReportField>
+                    <ReportField Name="EquipmentType">
+                    </ReportField>
+                    <ReportField Name="InventoryID">
+                    </ReportField>
+                    <ReportField Name="InventoryID_description">
+                    </ReportField>
+                    <ReportField Name="InventoryID_InventoryItem_descr">
+                    </ReportField>
+                    <ReportField Name="InventoryID_Segment1">
+                    </ReportField>
+                    <ReportField Name="LastModifiedByID">
+                    </ReportField>
+                    <ReportField Name="LastModifiedByID_description">
+                    </ReportField>
+                    <ReportField Name="LastModifiedByID_Modifier_displayName">
+                    </ReportField>
+                    <ReportField Name="LastModifiedByID_Modifier_Username">
+                    </ReportField>
+                    <ReportField Name="LastModifiedByScreenID">
+                    </ReportField>
+                    <ReportField Name="LastModifiedDateTime">
+                        <DataType>DateTime</DataType>
+                    </ReportField>
+                    <ReportField Name="LastModifiedDateTime_Day">
+                    </ReportField>
+                    <ReportField Name="LastModifiedDateTime_Hour">
+                    </ReportField>
+                    <ReportField Name="LastModifiedDateTime_Month">
+                    </ReportField>
+                    <ReportField Name="LastModifiedDateTime_Quarter">
+                    </ReportField>
+                    <ReportField Name="NoteActivity">
+                    </ReportField>
+                    <ReportField Name="NoteFiles">
+                    </ReportField>
+                    <ReportField Name="NoteID">
+                        <DataType>Object</DataType>
+                    </ReportField>
+                    <ReportField Name="NoteImages">
+                    </ReportField>
+                    <ReportField Name="NoteText">
+                    </ReportField>
+                    <ReportField Name="PhysicalLocation">
+                    </ReportField>
+                    <ReportField Name="SerialNbr">
+                    </ReportField>
+                    <ReportField Name="SMEquipmentID">
+                    </ReportField>
+                    <ReportField Name="SMEquipmentID_description">
+                    </ReportField>
+                    <ReportField Name="SMEquipmentID_FSEquipment_descr">
+                    </ReportField>
+                    <ReportField Name="Status">
+                    </ReportField>
+                    <ReportField Name="Tstamp">
+                    </ReportField>
+                </Fields>
+                <FullName>CMMSlite.WO.WOEquipment</FullName>
+            </ReportTable>
+        </Tables>
+        <Version>20211215</Version>
+        <Sections>
+            <PageHeader Name="pageHeaderSection1">
+                <Height>1in</Height>
+                <Items>
+                    <Panel Name="panel1">
+                        <Location>0px, 48px</Location>
+                        <Size>720px, 48px</Size>
+                        <Style>
+                            <BackColor>AliceBlue</BackColor>
+                            <BorderStyle>
+                                <Bottom>Solid</Bottom>
+                                <Top>Solid</Top>
+                            </BorderStyle>
+                        </Style>
+                        <Items>
+                            <TextBox Name="textBox10">
+                                <Location>0px, 0px</Location>
+                                <Size>56px, 24px</Size>
+                                <Style>
+                                    <Font>
+                                        <Style>Bold</Style>
+                                    </Font>
+                                </Style>
+                                <Value>Type</Value>
+                                <WrapText>False</WrapText>
+                            </TextBox>
+                            <TextBox Name="textBox11">
+                                <Location>64px, 0px</Location>
+                                <Size>64px, 24px</Size>
+                                <Style>
+                                    <Font>
+                                        <Style>Bold</Style>
+                                    </Font>
+                                </Style>
+                                <Value>WO ID</Value>
+                                <WrapText>False</WrapText>
+                            </TextBox>
+                            <TextBox Name="textBox12">
+                                <Location>136px, 0px</Location>
+                                <Size>144px, 24px</Size>
+                                <Style>
+                                    <Font>
+                                        <Style>Bold</Style>
+                                    </Font>
+                                </Style>
+                                <Value>Class</Value>
+                                <WrapText>False</WrapText>
+                            </TextBox>
+                            <TextBox Name="textBox13">
+                                <Location>176px, 24px</Location>
+                                <Size>240px, 24px</Size>
+                                <Style>
+                                    <Font>
+                                        <Style>Bold</Style>
+                                    </Font>
+                                </Style>
+                                <Value>Equipment</Value>
+                                <WrapText>False</WrapText>
+                            </TextBox>
+                            <TextBox Name="textBox15">
+                                <Location>424px, 24px</Location>
+                                <Size>80px, 24px</Size>
+                                <Style>
+                                    <Font>
+                                        <Style>Bold</Style>
+                                    </Font>
+                                </Style>
+                                <Value>Requested</Value>
+                                <WrapText>False</WrapText>
+                            </TextBox>
+                            <TextBox Name="textBox16">
+                                <Location>504px, 24px</Location>
+                                <Size>72px, 24px</Size>
+                                <Style>
+                                    <Font>
+                                        <Style>Bold</Style>
+                                    </Font>
+                                </Style>
+                                <Value>Scheduled</Value>
+                                <WrapText>False</WrapText>
+                            </TextBox>
+                            <TextBox Name="textBox17">
+                                <Location>584px, 0px</Location>
+                                <Size>128px, 24px</Size>
+                                <Style>
+                                    <Font>
+                                        <Style>Bold</Style>
+                                    </Font>
+                                </Style>
+                                <Value>Status</Value>
+                                <WrapText>False</WrapText>
+                            </TextBox>
+                            <TextBox Name="textBox26">
+                                <Location>136px, 24px</Location>
+                                <Size>32px, 24px</Size>
+                                <Style>
+                                    <Font>
+                                        <Style>Bold</Style>
+                                    </Font>
+                                </Style>
+                                <Value>Crit</Value>
+                                <WrapText>False</WrapText>
+                            </TextBox>
+                            <TextBox Name="textBox27">
+                                <Location>288px, 0px</Location>
+                                <Size>288px, 24px</Size>
+                                <Style>
+                                    <Font>
+                                        <Style>Bold</Style>
+                                    </Font>
+                                </Style>
+                                <Value>Description</Value>
+                                <WrapText>False</WrapText>
+                            </TextBox>
+                        </Items>
+                    </Panel>
+                    <TextBox Name="textBox18">
+                        <Location>0px, 0px</Location>
+                        <Size>184px, 16px</Size>
+                        <Style>
+                            <Font>
+                                <Style>Bold</Style>
+                            </Font>
+                        </Style>
+                        <Value>CMMS WORK ORDERS</Value>
+                    </TextBox>
+                    <TextBox Name="textBox19">
+                        <Location>640px, 0px</Location>
+                        <Size>80px, 24px</Size>
+                        <Style>
+                            <TextAlign>Right</TextAlign>
+                        </Style>
+                        <Value>=[PageOf]</Value>
+                    </TextBox>
+                    <TextBox Name="textBox20">
+                        <Location>568px, 0px</Location>
+                        <Size>64px, 24px</Size>
+                        <Style>
+                            <Font>
+                                <Style>Bold</Style>
+                            </Font>
+                        </Style>
+                        <Value>Page:</Value>
+                    </TextBox>
+                    <TextBox Name="textBox21">
+                        <Location>568px, 24px</Location>
+                        <Size>64px, 24px</Size>
+                        <Style>
+                            <Font>
+                                <Style>Bold</Style>
+                            </Font>
+                        </Style>
+                        <Value>Date:</Value>
+                    </TextBox>
+                    <TextBox Name="textBox22">
+                        <Location>640px, 24px</Location>
+                        <Size>80px, 24px</Size>
+                        <Style>
+                            <TextAlign>Right</TextAlign>
+                        </Style>
+                        <Value>=[@Today]</Value>
+                    </TextBox>
+                    <TextBox Name="textBox23">
+                        <Location>0px, 24px</Location>
+                        <Size>40px, 24px</Size>
+                        <Style>
+                            <Font>
+                                <Style>Bold</Style>
+                            </Font>
+                        </Style>
+                        <Value>User:</Value>
+                    </TextBox>
+                    <TextBox Name="textBox24">
+                        <Location>48px, 24px</Location>
+                        <Size>176px, 24px</Size>
+                        <Value>=Report.GetDefUI('AccessInfo.DisplayName')</Value>
+                        <WrapText>False</WrapText>
+                    </TextBox>
+                </Items>
+            </PageHeader>
+            <Detail Name="detailSection1">
+                <Height>0.5in</Height>
+                <Items>
+                    <TextBox Name="textBox1">
+                        <Location>64px, 0px</Location>
+                        <Size>64px, 24px</Size>
+                        <Value>=[WOOrder.WorkOrderCD]</Value>
+                        <WrapText>False</WrapText>
+                    </TextBox>
+                    <TextBox Name="textBox2">
+                        <Location>0px, 0px</Location>
+                        <Size>56px, 24px</Size>
+                        <Value>=[WOOrder.WorkOrderType]</Value>
+                        <WrapText>False</WrapText>
+                    </TextBox>
+                    <TextBox Name="textBox25">
+                        <Location>136px, 24px</Location>
+                        <Size>32px, 24px</Size>
+                        <Value>=[WOEquipment.Criticality]</Value>
+                    </TextBox>
+                    <TextBox Name="textBox3">
+                        <Location>424px, 24px</Location>
+                        <Size>72px, 24px</Size>
+                        <Value>=[WOOrder.RequestDate]</Value>
+                        <WrapText>False</WrapText>
+                    </TextBox>
+                    <TextBox Name="textBox4">
+                        <Location>504px, 24px</Location>
+                        <Size>72px, 24px</Size>
+                        <Value>=[WOOrder.ScheduleDate]</Value>
+                        <WrapText>False</WrapText>
+                    </TextBox>
+                    <TextBox Name="textBox5">
+                        <Location>584px, 0px</Location>
+                        <Size>128px, 24px</Size>
+                        <Value>=[WOOrder.Status]</Value>
+                        <WrapText>False</WrapText>
+                    </TextBox>
+                    <TextBox Name="textBox6">
+                        <Location>136px, 0px</Location>
+                        <Size>144px, 24px</Size>
+                        <Value>=[WOClass.Descr]</Value>
+                        <WrapText>False</WrapText>
+                    </TextBox>
+                    <TextBox Name="textBox7">
+                        <Location>288px, 0px</Location>
+                        <Size>288px, 24px</Size>
+                        <Value>=[WOOrder.Descr]</Value>
+                        <WrapText>False</WrapText>
+                    </TextBox>
+                    <TextBox Name="textBox8">
+                        <Location>176px, 24px</Location>
+                        <Size>64px, 24px</Size>
+                        <Value>=[WOEquipment.EquipmentCD]</Value>
+                        <WrapText>False</WrapText>
+                    </TextBox>
+                    <TextBox Name="textBox9">
+                        <Location>248px, 24px</Location>
+                        <Size>168px, 24px</Size>
+                        <Value>=[WOEquipment.Descr]</Value>
+                        <WrapText>False</WrapText>
+                    </TextBox>
+                </Items>
+            </Detail>
+            <PageFooter Name="pageFooterSection1">
+                <Height>0.41667in</Height>
+            </PageFooter>
+        </Sections>
+    </Report>
+</Report>

--- a/Package/CMMS/_project/SiteMapNode_1bc8f56a_216a_4960_9a06_9c16d1918ad3.xml
+++ b/Package/CMMS/_project/SiteMapNode_1bc8f56a_216a_4960_9a06_9c16d1918ad3.xml
@@ -1,0 +1,43 @@
+﻿<SiteMapNode>
+    <data-set>
+        <relations format-version="3" relations-version="20190730" main-table="SiteMap">
+            <link from="MUIScreen (NodeID)" to="SiteMap (NodeID)" />
+            <link from="MUIWorkspace (WorkspaceID)" to="MUIScreen (WorkspaceID)" type="FromMaster" linkname="workspaceToScreen" split-location="yes" updateable="True" />
+            <link from="MUISubcategory (SubcategoryID)" to="MUIScreen (SubcategoryID)" type="FromMaster" updateable="True" />
+            <link from="MUITile (ScreenID)" to="SiteMap (ScreenID)" />
+            <link from="MUIWorkspace (WorkspaceID)" to="MUITile (WorkspaceID)" type="FromMaster" linkname="workspaceToTile" split-location="yes" updateable="True" />
+            <link from="MUIArea (AreaID)" to="MUIWorkspace (AreaID)" type="FromMaster" updateable="True" />
+            <link from="MUIPinnedScreen (NodeID, WorkspaceID)" to="MUIScreen (NodeID, WorkspaceID)" type="WeakIfEmpty" isEmpty="Username" />
+            <link from="MUIFavoriteWorkspace (WorkspaceID)" to="MUIWorkspace (WorkspaceID)" type="WeakIfEmpty" isEmpty="Username" />
+        </relations>
+        <layout>
+            <table name="SiteMap">
+                <table name="MUIScreen" uplink="(NodeID) = (NodeID)">
+                    <table name="MUIPinnedScreen" uplink="(NodeID, WorkspaceID) = (NodeID, WorkspaceID)" />
+                </table>
+                <table name="MUITile" uplink="(ScreenID) = (ScreenID)" />
+            </table>
+            <table name="MUIWorkspace">
+                <table name="MUIFavoriteWorkspace" uplink="(WorkspaceID) = (WorkspaceID)" />
+            </table>
+            <table name="MUISubcategory" />
+            <table name="MUIArea" />
+        </layout>
+        <data>
+            <SiteMap>
+                <row Title="CMMS Work Orders" Url="~/Frames/ReportLauncher.aspx?ID=WO603000.rpx" ScreenID="WO603000" NodeID="1bc8f56a-216a-4960-9a06-9c16d1918ad3" ParentID="00000000-0000-0000-0000-000000000000">
+                    <MUIScreen IsPortal="0" WorkspaceID="930dc0c1-c7bc-460e-ba09-da7c7a112f2a" Order="30" SubcategoryID="0b491e12-c58d-4e47-8a0d-96dd3a8ab395" />
+                </row>
+            </SiteMap>
+            <MUIWorkspace>
+                <row IsPortal="0" WorkspaceID="930dc0c1-c7bc-460e-ba09-da7c7a112f2a" Order="38" Title="CMMS" Icon="build" AreaID="62cfd5dc-8eb9-4e92-bbcd-e0a99eb5e5df" IsSystem="0" />
+            </MUIWorkspace>
+            <MUISubcategory>
+                <row IsPortal="0" SubcategoryID="0b491e12-c58d-4e47-8a0d-96dd3a8ab395" Order="1024" Name="Reports" Icon="" IsSystem="0" />
+            </MUISubcategory>
+            <MUIArea>
+                <row IsPortal="0" AreaID="62cfd5dc-8eb9-4e92-bbcd-e0a99eb5e5df" Order="20" Name="Operations" />
+            </MUIArea>
+        </data>
+    </data-set>
+</SiteMapNode>

--- a/Package/CMMS/_project/SiteMapNode_22fa3e0d_3971_4c96_95a1_b43460c4a641.xml
+++ b/Package/CMMS/_project/SiteMapNode_22fa3e0d_3971_4c96_95a1_b43460c4a641.xml
@@ -1,0 +1,43 @@
+﻿<SiteMapNode>
+    <data-set>
+        <relations format-version="3" relations-version="20190730" main-table="SiteMap">
+            <link from="MUIScreen (NodeID)" to="SiteMap (NodeID)" />
+            <link from="MUIWorkspace (WorkspaceID)" to="MUIScreen (WorkspaceID)" type="FromMaster" linkname="workspaceToScreen" split-location="yes" updateable="True" />
+            <link from="MUISubcategory (SubcategoryID)" to="MUIScreen (SubcategoryID)" type="FromMaster" updateable="True" />
+            <link from="MUITile (ScreenID)" to="SiteMap (ScreenID)" />
+            <link from="MUIWorkspace (WorkspaceID)" to="MUITile (WorkspaceID)" type="FromMaster" linkname="workspaceToTile" split-location="yes" updateable="True" />
+            <link from="MUIArea (AreaID)" to="MUIWorkspace (AreaID)" type="FromMaster" updateable="True" />
+            <link from="MUIPinnedScreen (NodeID, WorkspaceID)" to="MUIScreen (NodeID, WorkspaceID)" type="WeakIfEmpty" isEmpty="Username" />
+            <link from="MUIFavoriteWorkspace (WorkspaceID)" to="MUIWorkspace (WorkspaceID)" type="WeakIfEmpty" isEmpty="Username" />
+        </relations>
+        <layout>
+            <table name="SiteMap">
+                <table name="MUIScreen" uplink="(NodeID) = (NodeID)">
+                    <table name="MUIPinnedScreen" uplink="(NodeID, WorkspaceID) = (NodeID, WorkspaceID)" />
+                </table>
+                <table name="MUITile" uplink="(ScreenID) = (ScreenID)" />
+            </table>
+            <table name="MUIWorkspace">
+                <table name="MUIFavoriteWorkspace" uplink="(WorkspaceID) = (WorkspaceID)" />
+            </table>
+            <table name="MUISubcategory" />
+            <table name="MUIArea" />
+        </layout>
+        <data>
+            <SiteMap>
+                <row Title="CMMS Work Order Detail" Url="~/Frames/ReportLauncher.aspx?ID=WO602000.rpx" ScreenID="WO602000" NodeID="22fa3e0d-3971-4c96-95a1-b43460c4a641" ParentID="00000000-0000-0000-0000-000000000000">
+                    <MUIScreen IsPortal="0" WorkspaceID="930dc0c1-c7bc-460e-ba09-da7c7a112f2a" Order="20" SubcategoryID="0b491e12-c58d-4e47-8a0d-96dd3a8ab395" />
+                </row>
+            </SiteMap>
+            <MUIWorkspace>
+                <row IsPortal="0" WorkspaceID="930dc0c1-c7bc-460e-ba09-da7c7a112f2a" Order="38" Title="CMMS" Icon="build" AreaID="62cfd5dc-8eb9-4e92-bbcd-e0a99eb5e5df" IsSystem="0" />
+            </MUIWorkspace>
+            <MUISubcategory>
+                <row IsPortal="0" SubcategoryID="0b491e12-c58d-4e47-8a0d-96dd3a8ab395" Order="1024" Name="Reports" Icon="" IsSystem="0" />
+            </MUISubcategory>
+            <MUIArea>
+                <row IsPortal="0" AreaID="62cfd5dc-8eb9-4e92-bbcd-e0a99eb5e5df" Order="20" Name="Operations" />
+            </MUIArea>
+        </data>
+    </data-set>
+</SiteMapNode>

--- a/Package/CMMS/_project/SiteMapNode_db594ca3_5fa8_4fe3_b7b9_07a2f97b266c.xml
+++ b/Package/CMMS/_project/SiteMapNode_db594ca3_5fa8_4fe3_b7b9_07a2f97b266c.xml
@@ -1,0 +1,43 @@
+﻿<SiteMapNode>
+    <data-set>
+        <relations format-version="3" relations-version="20190730" main-table="SiteMap">
+            <link from="MUIScreen (NodeID)" to="SiteMap (NodeID)" />
+            <link from="MUIWorkspace (WorkspaceID)" to="MUIScreen (WorkspaceID)" type="FromMaster" linkname="workspaceToScreen" split-location="yes" updateable="True" />
+            <link from="MUISubcategory (SubcategoryID)" to="MUIScreen (SubcategoryID)" type="FromMaster" updateable="True" />
+            <link from="MUITile (ScreenID)" to="SiteMap (ScreenID)" />
+            <link from="MUIWorkspace (WorkspaceID)" to="MUITile (WorkspaceID)" type="FromMaster" linkname="workspaceToTile" split-location="yes" updateable="True" />
+            <link from="MUIArea (AreaID)" to="MUIWorkspace (AreaID)" type="FromMaster" updateable="True" />
+            <link from="MUIPinnedScreen (NodeID, WorkspaceID)" to="MUIScreen (NodeID, WorkspaceID)" type="WeakIfEmpty" isEmpty="Username" />
+            <link from="MUIFavoriteWorkspace (WorkspaceID)" to="MUIWorkspace (WorkspaceID)" type="WeakIfEmpty" isEmpty="Username" />
+        </relations>
+        <layout>
+            <table name="SiteMap">
+                <table name="MUIScreen" uplink="(NodeID) = (NodeID)">
+                    <table name="MUIPinnedScreen" uplink="(NodeID, WorkspaceID) = (NodeID, WorkspaceID)" />
+                </table>
+                <table name="MUITile" uplink="(ScreenID) = (ScreenID)" />
+            </table>
+            <table name="MUIWorkspace">
+                <table name="MUIFavoriteWorkspace" uplink="(WorkspaceID) = (WorkspaceID)" />
+            </table>
+            <table name="MUISubcategory" />
+            <table name="MUIArea" />
+        </layout>
+        <data>
+            <SiteMap>
+                <row Title="CMMS Equipment" Url="~/Frames/ReportLauncher.aspx?ID=WO601000.rpx" ScreenID="WO601000" NodeID="db594ca3-5fa8-4fe3-b7b9-07a2f97b266c" ParentID="00000000-0000-0000-0000-000000000000">
+                    <MUIScreen IsPortal="0" WorkspaceID="930dc0c1-c7bc-460e-ba09-da7c7a112f2a" Order="10" SubcategoryID="0b491e12-c58d-4e47-8a0d-96dd3a8ab395" />
+                </row>
+            </SiteMap>
+            <MUIWorkspace>
+                <row IsPortal="0" WorkspaceID="930dc0c1-c7bc-460e-ba09-da7c7a112f2a" Order="38" Title="CMMS" Icon="build" AreaID="62cfd5dc-8eb9-4e92-bbcd-e0a99eb5e5df" IsSystem="0" />
+            </MUIWorkspace>
+            <MUISubcategory>
+                <row IsPortal="0" SubcategoryID="0b491e12-c58d-4e47-8a0d-96dd3a8ab395" Order="1024" Name="Reports" Icon="" IsSystem="0" />
+            </MUISubcategory>
+            <MUIArea>
+                <row IsPortal="0" AreaID="62cfd5dc-8eb9-4e92-bbcd-e0a99eb5e5df" Order="20" Name="Operations" />
+            </MUIArea>
+        </data>
+    </data-set>
+</SiteMapNode>

--- a/Package/CMMS/_project/Sql_WOLineTool.xml
+++ b/Package/CMMS/_project/Sql_WOLineTool.xml
@@ -4,8 +4,7 @@
   <col name="WorkOrderID" type="Int" />
   <col name="WOLineNbr" type="Int" />
   <col name="LineNbr" type="Int" />
-  <col name="InventoryID" type="Int" nullable="true" />
-  <col name="SubItemID" type="Int" nullable="true" />
+  <col name="EquipmentID" type="Int" nullable="true" />
   <col name="Quantity" type="Decimal(25,6)" nullable="true" />
   <col name="BaseUnit" type="NVarChar(8)" nullable="true" />
   <col name="CreatedByID" type="UniqueIdentifier" />


### PR DESCRIPTION
Addresses Issues: 17, 10, 44, 45, and 46

Add base reports for:
- Equipment
- Work Orders (list) with filters
- Work Order Details

Adds Attributes back to the Work Order screen.  Also restores placement of instruction to the left side of the grid rather than the Equipment ID as Equipment ID is optional, but the instruction is the primary focus of the operation.

Resolves a bug introduced in a previous build that prevented adding a new operation to the work order

Changes Inventory ID for tools on a Work Order to utilize Equipment of type Tool

Repositions Inventory ID on the Equipment screen to a lower prominence as a reference field